### PR TITLE
correcting waConfigureDetectedApps function

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -189,8 +189,8 @@ CATEGORIES=\"WinApps\"
 
 # GNOME mimetypes
 MIME_TYPES=\"\"
-" > "${SYS_PATH}/apps/${EXE}/info"
-						echo "${ICONS[$I]}" | base64 -d > "${SYS_PATH}/apps/${EXE}/icon.ico"
+" | sudo tee "${SYS_PATH}/apps/${EXE}/info" > /dev/null
+ 						echo "${ICONS[$I]}" | base64 -d | sudo tee "${SYS_PATH}/apps/${EXE}/icon.ico" > /dev/null
 						waConfigureApp "${EXE}" ico
 						COUNT=$((COUNT + 1))
 					fi


### PR DESCRIPTION
When utilizing the installer bash script as system and selecting individual apps on the second "How would you like to handle other detected applications?" question, the result will end in an error. 
`
./installer.sh: line 192: /usr/local/share/winapps/apps/msedge.exe/info: Permission denied
./installer.sh: line 193: /usr/local/share/winapps/apps/msedge.exe/icon.ico: Permission denied
./installer.sh: line 78: /usr/local/share/winapps/apps/msedge.exe/info: No such file or directory
  Configuring Microsoft Edge... Finished.
Installation complete.
`
This is due to permissions within the /usr/local/share/winapps/apps directory, which on a relatively unused Ubuntu 22.04 installation was root:root. To rectify this, a 'sudo tee' was added to lines 192 and 193 in order to be able to create the info file and icon.ico, which resulted in a successful creation of info and icon.ico, as well as the installation of MS Edge, in this case, to the host system. 