### PR TITLE
Several Fixes (freerdp3 command line, able to be run on multiple distros, fixing a typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # winapps
-The winapps main project 
+
+The winapps main project
 Originally created by fmstrat https://github.com/Fmstrat/winapps/
 
 Run Windows apps such as Microsoft Office/Adobe in Linux (Ubuntu/Fedora) and GNOME/KDE as if they were a part of the native OS, including Nautilus integration for right clicking on files of specific mime types to open them.
@@ -7,7 +8,9 @@ Run Windows apps such as Microsoft Office/Adobe in Linux (Ubuntu/Fedora) and GNO
 <img src="demo/demo.gif" width=1000>
 
 ## How it works
+
 WinApps was created as an easy, one command way to include apps running inside a VM (or on any RDP server) directly into GNOME as if they were native applications. WinApps works by:
+
 - Running a Windows RDP server in a background VM container
 - Checking the RDP server for installed applications such as Microsoft Office
 - If those programs are installed, it creates shortcuts leveraging FreeRDP for both the CLI and the GNOME tray
@@ -15,9 +18,11 @@ WinApps was created as an easy, one command way to include apps running inside a
 - You can right click on any files in your home directory to open with an application, too
 
 ## Currently supported applications
-### WinApps supports ***ANY*** installed application on your system.
+
+### WinApps supports **_ANY_** installed application on your system.
 
 It does this by:
+
 1. Scanning your system for offically configured applications (below)
 2. Scanning your system for any other EXE files with install records in the Windows Registry
 
@@ -75,6 +80,7 @@ Note: The officially configured application list below is fueled by the communit
 ## Installation
 
 ### Step 1: Set up a Windows Virtual Machine
+
 The best solution for running a VM as a subsystem for WinApps would be KVM. KVM is a CPU and memory-efficient virtualization engine bundled with most major Linux distributions. To set up the VM for WinApps, follow this guide:
 
 - [Creating a Virtual Machine in KVM](docs/KVM.md)
@@ -82,8 +88,10 @@ The best solution for running a VM as a subsystem for WinApps would be KVM. KVM 
 If you already have a Virtual Machine or server you wish to use with WinApps, you will need to merge `install/RDPApps.reg` into the VM's Windows Registry. If this VM is in KVM and you want to use auto-IP detection, you will need to name the machine `RDPWindows` (auto-IP detection not supported for non-KVM VMs). Directions for both of these can be found in the guide linked above.
 
 ### Step 2: Download the repo and prerequisites
+
 To get things going, use:
-``` bash
+
+```bash
 sudo apt install -y freerdp2-x11
 git clone https://github.com/winapps-org/winapps.git
 cd winapps
@@ -94,8 +102,10 @@ cd winapps
 > You can find nightly builds here: https://github.com/FreeRDP/FreeRDP/wiki/Prebuilds
 
 ### Step 3: Creating your WinApps configuration file
+
 You will need to create a `~/.config/winapps/winapps.conf` configuration file with the following information in it:
-``` bash
+
+```bash
 RDP_USER="MyWindowsUser"
 RDP_PASS="MyWindowsPassword"
 #RDP_DOMAIN="MYDOMAIN"
@@ -104,10 +114,13 @@ RDP_PASS="MyWindowsPassword"
 #RDP_FLAGS=""
 #MULTIMON="true"
 #DEBUG="true"
+#FREERDP_COMMAND="xfreerdp"
 ```
+
 The username and password should be a full user account and password, such as the one created when setting up Windows or a domain user. It cannot be a user/PIN combination as those are not valid for RDP access.
 
 Options:
+
 - When using a pre-existing non-KVM RDP server, you must use the `RDP_IP` to specify it's location
 - If you are running a VM in KVM with NAT enabled, leave `RDP_IP` commented out and WinApps will auto-detect the right local IP
 - For domain users, you can uncomment and change `RDP_DOMAIN`
@@ -115,15 +128,20 @@ Options:
 - To add flags to the FreeRDP call, such as `/audio-mode:1` to pass in a mic, use the `RDP_FLAGS` configuration option
 - For multi-monitor setups, you can try enabling `MULTIMON`, however if you get a black screen (FreeRDP bug) you will need to revert back
 - If you enable `DEBUG`, a log will be created on each application start in `~/.local/share/winapps/winapps.log`
+- If you are on a system, where the command for freeredp is not xfreerdp, change `FREERDP_COMMAND` to it.
 
 ### Step 4: Run the WinApps installer
+
 Lastly, check that FreeRDP can connect with:
+
 ```
 bin/winapps check
 ```
+
 You will see output from FreeRDP, as well as potentially have to accept the initial certificate. After that, a Windows Explorer window should pop up. You can close this window and press `Ctrl-C` to cancel out of FreeRDP.
 
 If this step fails, try restarting the VM, or your problem could be related to:
+
 - You need to accept the security cert the first time you connect (with 'check')
 - Not enabling RDP in the Windows VM
 - Not being able to connect to the IP of the VM
@@ -131,16 +149,19 @@ If this step fails, try restarting the VM, or your problem could be related to:
 - Not merging `install/RDPApps.reg` into the VM
 
 Then the final step is to run the installer which will prompt you for a system or user install:
-``` bash
+
+```bash
 ./installer.sh
 ```
+
 This will take you through the following process:
 
 <img src="demo/installer.gif" width=1000>
 
-
 ## Adding pre-defined applications
+
 Adding applications with custom icons and mime types to the installer is easy. Simply copy one of the application configurations in the `apps` folder, and:
+
 - Edit the variables for the application
 - Replace the `icon.svg` with an SVG for the application (appropriately licensed)
 - Re-run the installer
@@ -149,21 +170,27 @@ Adding applications with custom icons and mime types to the installer is easy. S
 When running the installer, it will check for if any configured apps are installed, and if they are it will create the appropriate shortcuts on the host OS.
 
 ## Running applications manually
+
 WinApps offers a manual mode for running applications that are not configured. This is completed with the `manual` flag. Executables that are in the path do not require full path definition.
-``` bash
+
+```bash
 ./bin/winapps manual "C:\my\directory\executableNotInPath.exe"
 ./bin/winapps manual executableInPath.exe
 ```
 
 ## Checking for new application support
+
 The installer can be run multiple times, so simply run the below again and it will remove any current installations and update for the latest applications.
-``` bash
+
+```bash
 ./installer.sh
 ```
 
 ## Optional installer command line arguments
+
 The following optional commands can be used to manage your application configurations without prompts:
-``` bash
+
+```bash
 ./installer.sh --user                # Configure applications for the current user
 ./installer.sh --system              # Configure applications for the entire system
 ./installer.sh --user --uninstall    # Remove all configured applications for the current user
@@ -171,9 +198,9 @@ The following optional commands can be used to manage your application configura
 ```
 
 ## Shout outs
+
 - Some icons pulled from
-  - Fluent UI React - Icons under [MIT License](https://github.com/Fmstrat/fluent-ui-react/blob/master/LICENSE.md) 
+  - Fluent UI React - Icons under [MIT License](https://github.com/Fmstrat/fluent-ui-react/blob/master/LICENSE.md)
   - Fluent UI - Icons under [MIT License](https://github.com/Fmstrat/fluentui/blob/master/LICENSE) with [restricted use](https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_nov_2019.pdf)
   - PKief's VSCode Material Icon Theme - Icons under [MIT License](https://github.com/Fmstrat/vscode-material-icon-theme/blob/master/LICENSE.md)
   - DiemenDesign's LibreICONS - Icons under [MIT License](https://github.com/Fmstrat/LibreICONS/blob/master/LICENSE)
-  

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ The following optional commands can be used to manage your application configura
 ./installer.sh --user --uninstall    # Remove all configured applications for the current user
 ./installer.sh --system --uninstall  # Remove all configured applications for the entire system
 ```
-./installer.sh --user --setupAllOfficiallySupportedApps    # Configures all officially support applications for the current user
-./installer.sh --system --setupAllOfficiallySupportedApps  # Configures all officially support applications for the entire system
+./installer.sh --user --setupAllOfficiallySupportedApps    # Configures all officially supported applications for the current user
+./installer.sh --system --setupAllOfficiallySupportedApps  # Configures all officially supported applications for the entire system
 ```
 
 ## Shout outs

--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ The following optional commands can be used to manage your application configura
 ./installer.sh --system              # Configure applications for the entire system
 ./installer.sh --user --uninstall    # Remove all configured applications for the current user
 ./installer.sh --system --uninstall  # Remove all configured applications for the entire system
-```
 ./installer.sh --user --setupAllOfficiallySupportedApps    # Configures all officially supported applications for the current user
 ./installer.sh --system --setupAllOfficiallySupportedApps  # Configures all officially supported applications for the entire system
 ```

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ The following optional commands can be used to manage your application configura
 ./installer.sh --user --uninstall    # Remove all configured applications for the current user
 ./installer.sh --system --uninstall  # Remove all configured applications for the entire system
 ```
+./installer.sh --user --setupAllOfficiallySupportedApps    # Configures all officially support applications for the current user
+./installer.sh --system --setupAllOfficiallySupportedApps  # Configures all officially support applications for the entire system
+```
 
 ## Shout outs
 

--- a/apps/iexplorer/info
+++ b/apps/iexplorer/info
@@ -8,7 +8,7 @@ FULL_NAME="Internet Explorer"
 WIN_EXECUTABLE="C:\Program Files\Internet Explorer\iexplore.exe"
 
 # GNOME categories
-CATEGORIES="WinApps;Office"
+CATEGORIES="WinApps;Network;WebBrowser;"
 
 # GNOME mimetypes
 MIME_TYPES="text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;"

--- a/bin/winapps
+++ b/bin/winapps
@@ -49,7 +49,11 @@ if [ -z "${FREERDP_COMMAND}" ]; then
 		FREERDP_COMMAND="xfreerdp3"
 	fi
 else
-	dprint "Using custom freerdp command ${FREERDP_COMMAND}"
+	if command -v $FREERDP_COMMAND &> /dev/null
+		dprint "Using custom freerdp command ${FREERDP_COMMAND}"
+	else
+		echo "You have supplied a custom FreeRDP command, but the command is not available."
+	fi
 fi
 
 if [ -z "${RDP_IP}" ]; then

--- a/bin/winapps
+++ b/bin/winapps
@@ -53,6 +53,7 @@ else
 		dprint "Using custom freerdp command ${FREERDP_COMMAND}"
 	else
 		echo "You have supplied a custom FreeRDP command, but the command is not available."
+		exit
 	fi
 fi
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -33,7 +33,7 @@ if [ -f "${HOME}/.local/share/winapps/run" ]; then
 	touch "${HOME}/.local/share/winapps/run"
 	THIS_RUN=$(stat -t -c %Y "${HOME}/.local/share/winapps/run")
 	dprint "THIS_RUN:${THIS_RUN}"
-	if (($THIS_RUN - $LAST_RAN < 2)); then
+	if ((THIS_RUN - LAST_RAN < 2)); then
 		exit
 	fi
 else
@@ -57,13 +57,13 @@ else
 fi
 
 if [ -z "${RDP_IP}" ]; then
-	if [ -z "$(groups | grep libvirt)" ]; then
+	if [ ! "$(groups | grep -v libvirt)" ]; then
 		echo "You are not a member of the libvirt group. Run the below then reboot."
 		echo '  sudo usermod -a -G libvirt $(whoami)'
 		echo '  sudo usermod -a -G kvm $(whoami)'
 		exit
 	fi
-	if [ -z "$(virsh list | grep RDPWindows)" ]; then
+	if [ ! "$(virsh list | grep -v RDPWindows)" ]; then
 		echo "RDPWindows is not running, run:"
 		echo "  virsh start RDPWindows"
 		exit
@@ -75,6 +75,8 @@ fi
 
 dprint "1:${1}"
 dprint "2:${2}"
+# this is just for debug logging anyways
+# shellcheck disable=SC2145
 dprint "@:${@}"
 
 MULTI_FLAG="+span"
@@ -86,32 +88,35 @@ if [ "${1}" = "windows" ]; then
 	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +dynamic-resolution +auto-reconnect +home-drive /wm-class:"Microsoft Windows" /v:${RDP_IP} 1>/dev/null 2>&1 &
 elif [ "${1}" = "check" ]; then
 	dprint "CHECK"
-	$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /app:program:"explorer.exe" /v:${RDP_IP}
+	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /app:program:"explorer.exe" /v:${RDP_IP}
 elif [ "${1}" = "manual" ]; then
 	dprint "MANUAL:${2}"
-	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +home-drive +dynamic-resolution ${MULTI_FLAG} /app:programm:"${2}" /v:${RDP_IP} 1>/dev/null 2>&1 &
+	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +home-drive +dynamic-resolution ${MULTI_FLAG} /app:program:"${2}" /v:"${RDP_IP}" 1>/dev/null 2>&1 &
 elif [ "${1}" != "install" ]; then
 	dprint "DIR:${DIR}"
 	if [ -e "${DIR}/../apps/${1}/info" ]; then
+		# shellcheck disable=SC1090
 		. "${DIR}/../apps/${1}/info"
 		ICON="${DIR}/../apps/${1}/icon.svg"
 	elif [ -e "${HOME}/.local/share/winapps/apps/${1}/info" ]; then
+		# shellcheck disable=SC1090
 		. "${HOME}/.local/share/winapps/apps/${1}/info"
 		ICON="${HOME}/.local/share/winapps/apps/${1}/icon.svg"
 	elif [ -e "/usr/local/share/winapps/apps/${1}/info" ]; then
+		# shellcheck disable=SC1090
 		. "/usr/local/share/winapps/apps/${1}/info"
 		ICON="/usr/local/share/winapps/apps/${1}/icon.svg"
 	else
-		echo "You need to run 'install.sh' first."
+		echo "You need to run 'installer.sh' first."
 		exit 1
 	fi
 	if [ -n "${2}" ]; then
 		dprint "HOME:${HOME}"
 		FILE=$(echo "${2}" | sed 's|'"${HOME}"'|\\\\tsclient\\home|;s|/|\\|g;s|\\|\\\\|g')
 		dprint "FILE:${FILE}"
-		$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}",cmd:"\"$FILE\"" /v:${RDP_IP} 1>/dev/null 2>&1 &
+		$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}",cmd:"\"$FILE\"" /v:"${RDP_IP}" 1>/dev/null 2>&1 &
 	else
-		$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}" /v:${RDP_IP} 1>/dev/null 2>&1 &
+		$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}" /v:"${RDP_IP}" 1>/dev/null 2>&1 &
 	fi
 fi
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -4,7 +4,6 @@ if [ ! -f "${HOME}/.config/winapps/winapps.conf" ] && [ ! -f "${HOME}/.winapps" 
 	echo "You need to create a ~/.config/winapps/winapps.conf configuration. Exiting..."
 	exit
 fi
-
 DIR="$(dirname "$(readlink -f "$0")")"
 RUN="$(date)-${RANDOM}"
 
@@ -22,7 +21,7 @@ fi
 
 function dprint() {
 	if [ "${DEBUG}" = "true" ]; then
-		echo "[${RUN}] ${1}" >> "${HOME}/.local/share/winapps/winapps.log"
+		echo "[${RUN}] ${1}" >>"${HOME}/.local/share/winapps/winapps.log"
 	fi
 }
 
@@ -34,52 +33,59 @@ if [ -f "${HOME}/.local/share/winapps/run" ]; then
 	touch "${HOME}/.local/share/winapps/run"
 	THIS_RUN=$(stat -t -c %Y "${HOME}/.local/share/winapps/run")
 	dprint "THIS_RUN:${THIS_RUN}"
-	if (( $THIS_RUN - $LAST_RAN < 2 )); then
+	if (($THIS_RUN - $LAST_RAN < 2)); then
 		exit
 	fi
 else
 	touch "${HOME}/.local/share/winapps/run"
 fi
 
-if [ -z "$(which xfreerdp)" ]; then
-	echo "You need xfreerdp!"
-	echo "  sudo apt-get install -y freerdp2-x11"
-	exit
+if [ -z "${FREERDP_COMMAND}" ]; then
+	if command -v xfreerdp &> /dev/null
+	then
+		FREERDP_COMMAND="xfreerdp"
+	elif command -v xfreerdp3 &> /dev/null
+	then
+		FREERDP_COMMAND="xfreerdp3"
+	fi
+else
+	dprint "Using custom freerdp command ${FREERDP_COMMAND}"
 fi
 
 if [ -z "${RDP_IP}" ]; then
-	if [ -z "$(groups |grep libvirt)" ]; then
+	if [ -z "$(groups | grep libvirt)" ]; then
 		echo "You are not a member of the libvirt group. Run the below then reboot."
 		echo '  sudo usermod -a -G libvirt $(whoami)'
 		echo '  sudo usermod -a -G kvm $(whoami)'
 		exit
 	fi
-	if [ -z "$(virsh list |grep RDPWindows)" ]; then
+	if [ -z "$(virsh list | grep RDPWindows)" ]; then
 		echo "RDPWindows is not running, run:"
 		echo "  virsh start RDPWindows"
 		exit
 	fi
-	RDP_IP=$(virsh net-dhcp-leases default |grep RDPWindows |awk '{print $5}')
+	RDP_IP=$(virsh net-dhcp-leases default | grep RDPWindows | awk '{print $5}')
 	RDP_IP=${RDP_IP%%\/*}
+
 fi
 
 dprint "1:${1}"
 dprint "2:${2}"
 dprint "@:${@}"
 
-MULTI_FLAG="span"
+MULTI_FLAG="+span"
 if [ "${MULTIMON}" = "true" ]; then
-	MULTI_FLAG="multimon"
+	MULTI_FLAG="/multimon"
 fi
 
 if [ "${1}" = "windows" ]; then
-	xfreerdp ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} /scale:${RDP_SCALE} /dynamic-resolution +auto-reconnect +home-drive /wm-class:"Microsoft Windows" 1> /dev/null 2>&1 &
+	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +dynamic-resolution +auto-reconnect +home-drive /wm-class:"Microsoft Windows" /v:${RDP_IP} 1>/dev/null 2>&1 &
 elif [ "${1}" = "check" ]; then
 	dprint "CHECK"
-	xfreerdp ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +home-drive -wallpaper /scale:${RDP_SCALE} /dynamic-resolution /${MULTI_FLAG} /app:"explorer.exe"
+	$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /app:program:"explorer.exe" /v:${RDP_IP}
 elif [ "${1}" = "manual" ]; then
 	dprint "MANUAL:${2}"
-	xfreerdp ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +home-drive -wallpaper /scale:${RDP_SCALE} /dynamic-resolution /${MULTI_FLAG} /app:"${2}" 1> /dev/null 2>&1 &
+	$FREERDP_COMMAND ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /scale:${RDP_SCALE} +auto-reconnect +home-drive +dynamic-resolution ${MULTI_FLAG} /app:programm:"${2}" /v:${RDP_IP} 1>/dev/null 2>&1 &
 elif [ "${1}" != "install" ]; then
 	dprint "DIR:${DIR}"
 	if [ -e "${DIR}/../apps/${1}/info" ]; then
@@ -99,9 +105,9 @@ elif [ "${1}" != "install" ]; then
 		dprint "HOME:${HOME}"
 		FILE=$(echo "${2}" | sed 's|'"${HOME}"'|\\\\tsclient\\home|;s|/|\\|g;s|\\|\\\\|g')
 		dprint "FILE:${FILE}"
-		xfreerdp ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +clipboard +home-drive -wallpaper /scale:${RDP_SCALE} /dynamic-resolution /${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${ICON}" /app-cmd:"\"${FILE}\"" 1> /dev/null 2>&1 &
+		$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}",cmd:"\"$FILE\"" /v:${RDP_IP} 1>/dev/null 2>&1 &
 	else
-		xfreerdp ${RDP_FLAGS} /d:"${RDP_DOMAIN}" /u:"${RDP_USER}" /p:"${RDP_PASS}" /v:${RDP_IP} +auto-reconnect +clipboard +home-drive -wallpaper /scale:${RDP_SCALE} /dynamic-resolution /${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:"${WIN_EXECUTABLE}" /app-icon:"${ICON}" 1> /dev/null 2>&1 &
+		$FREERDP_COMMAND ${RDP_FLAGS} /d:${RDP_DOMAIN} /u:${RDP_USER} /p:${RDP_PASS} /scale:${RDP_SCALE} +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution ${MULTI_FLAG} /wm-class:"${FULL_NAME}" /app:program:"${WIN_EXECUTABLE}",icon:"${ICON}",name:"${FULL_NAME}" /v:${RDP_IP} 1>/dev/null 2>&1 &
 	fi
 fi
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -48,13 +48,12 @@ if [ -z "${FREERDP_COMMAND}" ]; then
 	then
 		FREERDP_COMMAND="xfreerdp3"
 	fi
-else
-	if command -v $FREERDP_COMMAND &> /dev/null
+elif command -v $FREERDP_COMMAND &> /dev/null
+then
 		dprint "Using custom freerdp command ${FREERDP_COMMAND}"
-	else
-		echo "You have supplied a custom FreeRDP command, but the command is not available."
-		exit
-	fi
+else
+	echo "You have supplied a custom FreeRDP command, but the command is not available."
+	exit
 fi
 
 if [ -z "${RDP_IP}" ]; then

--- a/installer.sh
+++ b/installer.sh
@@ -118,7 +118,7 @@ function waConfigureApps() {
 	
 	if [ "${INSTALL_TYPE}" != 'User' ]; then
 		menuFromArr APP_INSTALL "How would you like to handle WinApps pre-configured applications?" "${OPTIONS[@]}"
-	else"grep -l -d skip"
+	else "grep -l -d skip"
 		menuFromArr APP_INSTALL "How would you like to handle WinApps pre-configured applications? If any web browser is set-up, may be configured as default browser." "${OPTIONS[@]}"
 	fi
 	if [ "${APP_INSTALL}" = "Select which pre-configured applications to set up" ]; then


### PR DESCRIPTION
… to install all officially supported apps in one go, also fix a typo

This PR contains Several Fixes.
With FreeRDP3, the command line interface has been reworked, making the old one non-compatible.

Several of the commands given here made the baseline assumption that it is run on Ubuntu, like the assumption the command is always named "xfreerdp", when at least under Arch it is xfreerdp3. So the check for that is also in, and the option to supply an own command there. 
Or the base assumption that bc is installed (it isnt under arch)

It also adds an convenience argument to setup all officially supported apps at once. 

Also, there was an typo for the Windows launcher, telling us it belonged to "Micorosoft" instead of Microsoft