### PR TITLE
Prefer to use Theme Icons

### DIFF
--- a/apps/adobe-cc/info
+++ b/apps/adobe-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES=""
+
+# System Icon
+ICON="AdobeUpdate"

--- a/apps/aftereffects-cc/info
+++ b/apps/aftereffects-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.adobe.aftereffects.project;application/vnd.adobe.aftereffects.template;"
+
+# System Icon
+ICON="AdobeAfterEffect"

--- a/apps/audition-cc/info
+++ b/apps/audition-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES=""
+
+# System Icon
+ICON="AdobeAudition"

--- a/apps/bridge-cc/info
+++ b/apps/bridge-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobeBridge"

--- a/apps/bridge-cs6-x86/info
+++ b/apps/bridge-cs6-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobeBridge"

--- a/apps/bridge-cs6/info
+++ b/apps/bridge-cs6/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobeBridge"

--- a/apps/cmd/info
+++ b/apps/cmd/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Windows"
 
 # GNOME mimetypes
 MIME_TYPES=""
+
+# System Icon
+ICON="Terminal"

--- a/apps/excel-o365-x86/info
+++ b/apps/excel-o365-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-excel;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.openxmlformats-officedocument.spreadsheetml.template;application/vnd.ms-excel.sheet.macroEnabled.12;application/vnd.ms-excel.template.macroEnabled.12;application/vnd.ms-excel.addin.macroEnabled.12;application/vnd.ms-excel.sheet.binary.macroEnabled.12;"
+
+# System Icon
+ICON="ms-excel"s

--- a/apps/excel-o365/info
+++ b/apps/excel-o365/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-excel;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.openxmlformats-officedocument.spreadsheetml.template;application/vnd.ms-excel.sheet.macroEnabled.12;application/vnd.ms-excel.template.macroEnabled.12;application/vnd.ms-excel.addin.macroEnabled.12;application/vnd.ms-excel.sheet.binary.macroEnabled.12;"
+
+# System Icon
+ICON="ms-excel"

--- a/apps/excel-x86/info
+++ b/apps/excel-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-excel;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.openxmlformats-officedocument.spreadsheetml.template;application/vnd.ms-excel.sheet.macroEnabled.12;application/vnd.ms-excel.template.macroEnabled.12;application/vnd.ms-excel.addin.macroEnabled.12;application/vnd.ms-excel.sheet.binary.macroEnabled.12;"
+
+# System Icon
+ICON="ms-excel"

--- a/apps/excel/info
+++ b/apps/excel/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-excel;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.openxmlformats-officedocument.spreadsheetml.template;application/vnd.ms-excel.sheet.macroEnabled.12;application/vnd.ms-excel.template.macroEnabled.12;application/vnd.ms-excel.addin.macroEnabled.12;application/vnd.ms-excel.sheet.binary.macroEnabled.12;"
+
+# System Icon
+ICON="ms-excel"

--- a/apps/illustrator-cc/info
+++ b/apps/illustrator-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="application/illustrator;"
+
+# System Icon
+ICON="AdobeIllustrator"

--- a/apps/indesign-cc/info
+++ b/apps/indesign-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="application/x-adobe-indesign-interchange;application/x-adobe-indesign;"
+
+# System Icon
+ICON="AdobeIndesign"

--- a/apps/lightroom-cc/info
+++ b/apps/lightroom-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES=""
+
+# System Icon
+ICON="AdobeLightroom"

--- a/apps/onenote-o365-x86/info
+++ b/apps/onenote-o365-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msonenote;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/onenote-o365/info
+++ b/apps/onenote-o365/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msonenote;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/onenote-x86/info
+++ b/apps/onenote-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msonenote;"
+
+# System Icon
+ICON="ms-onenote"

--- a/apps/onenote/info
+++ b/apps/onenote/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msonenote;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/outlook-o365-x86/info
+++ b/apps/outlook-o365-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-outlook;application/octet-stream;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/outlook-o365/info
+++ b/apps/outlook-o365/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-outlook;application/octet-stream;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/outlook-x86/info
+++ b/apps/outlook-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-outlook;application/octet-stream;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/outlook/info
+++ b/apps/outlook/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-outlook;application/octet-stream;"
+
+# System Icon
+ICON="ms-outlook"

--- a/apps/photoshop-cc/info
+++ b/apps/photoshop-cc/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobePhotoshop"

--- a/apps/photoshop-cs6-x86/info
+++ b/apps/photoshop-cs6-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobePhotoshop"

--- a/apps/photoshop-cs6/info
+++ b/apps/photoshop-cs6/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Adobe"
 
 # GNOME mimetypes
 MIME_TYPES="image/vnd.adobe.photoshop;"
+
+# System Icon
+ICON="AdobePhotoshop"

--- a/apps/powerpoint-o365-x86/info
+++ b/apps/powerpoint-o365-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-powerpoint;application/vnd.openxmlformats-officedocument.presentationml.presentation;application/vnd.openxmlformats-officedocument.presentationml.template;application/vnd.openxmlformats-officedocument.presentationml.slideshow;application/vnd.ms-powerpoint.addin.macroEnabled.12;application/vnd.ms-powerpoint.presentation.macroEnabled.12;application/vnd.ms-powerpoint.template.macroEnabled.12;application/vnd.ms-powerpoint.slideshow.macroEnabled.12;"
+
+# System Icon
+ICON="ms-powerpoint"

--- a/apps/powerpoint-o365/info
+++ b/apps/powerpoint-o365/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-powerpoint;application/vnd.openxmlformats-officedocument.presentationml.presentation;application/vnd.openxmlformats-officedocument.presentationml.template;application/vnd.openxmlformats-officedocument.presentationml.slideshow;application/vnd.ms-powerpoint.addin.macroEnabled.12;application/vnd.ms-powerpoint.presentation.macroEnabled.12;application/vnd.ms-powerpoint.template.macroEnabled.12;application/vnd.ms-powerpoint.slideshow.macroEnabled.12;"
+
+# System Icon
+ICON="ms-powerpoint"

--- a/apps/powerpoint-x86/info
+++ b/apps/powerpoint-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-powerpoint;application/vnd.openxmlformats-officedocument.presentationml.presentation;application/vnd.openxmlformats-officedocument.presentationml.template;application/vnd.openxmlformats-officedocument.presentationml.slideshow;application/vnd.ms-powerpoint.addin.macroEnabled.12;application/vnd.ms-powerpoint.presentation.macroEnabled.12;application/vnd.ms-powerpoint.template.macroEnabled.12;application/vnd.ms-powerpoint.slideshow.macroEnabled.12;"
+
+# System Icon
+ICON="ms-powerpoint"

--- a/apps/powerpoint/info
+++ b/apps/powerpoint/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-powerpoint;application/vnd.openxmlformats-officedocument.presentationml.presentation;application/vnd.openxmlformats-officedocument.presentationml.template;application/vnd.openxmlformats-officedocument.presentationml.slideshow;application/vnd.ms-powerpoint.addin.macroEnabled.12;application/vnd.ms-powerpoint.presentation.macroEnabled.12;application/vnd.ms-powerpoint.template.macroEnabled.12;application/vnd.ms-powerpoint.slideshow.macroEnabled.12;"
+
+# System Icon
+ICON="ms-powerpoint"

--- a/apps/word-o365-x86/info
+++ b/apps/word-o365-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msword;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.wordprocessingml.template;application/vnd.ms-word.document.macroEnabled.12;application/vnd.ms-word.template.macroEnabled.12;"
+
+# System Icon
+ICON="ms-word"

--- a/apps/word-o365/info
+++ b/apps/word-o365/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msword;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.wordprocessingml.template;application/vnd.ms-word.document.macroEnabled.12;application/vnd.ms-word.template.macroEnabled.12;"
+
+# System Icon
+ICON="ms-word"

--- a/apps/word-x86/info
+++ b/apps/word-x86/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msword;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.wordprocessingml.template;application/vnd.ms-word.document.macroEnabled.12;application/vnd.ms-word.template.macroEnabled.12;"
+
+# System Icon
+ICON="ms-word"

--- a/apps/word/info
+++ b/apps/word/info
@@ -12,3 +12,6 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/msword;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.wordprocessingml.template;application/vnd.ms-word.document.macroEnabled.12;application/vnd.ms-word.template.macroEnabled.12;"
+
+# System Icon
+ICON="ms-word"

--- a/installer.sh
+++ b/installer.sh
@@ -75,16 +75,19 @@ function waFindInstalled() {
 }
 
 function waConfigureApp() {
-		. "${SYS_PATH}/apps/${1}/info"
-		echo -n "  Configuring ${NAME}..."
-		if [ ${USEDEMO} != 1 ]; then
-			${SUDO} rm -f "${APP_PATH}/${1}.desktop"
-			echo "[Desktop Entry]
+	if [ -z "${ICON}" ]; then
+		ICON=${SYS_PATH}/apps/${1}/icon.${2}
+	fi
+	. "${SYS_PATH}/apps/${1}/info"
+	echo -n "  Configuring ${NAME}..."
+	if [ ${USEDEMO} != 1 ]; then
+		${SUDO} rm -f "${APP_PATH}/${1}.desktop"
+		echo "[Desktop Entry]
 Name=${NAME}
 Exec=${BIN_PATH}/winapps ${1} %F
 Terminal=false
 Type=Application
-Icon=${SYS_PATH}/apps/${1}/icon.${2}
+Icon=$ICON
 StartupWMClass=${FULL_NAME}
 Comment=${FULL_NAME}
 Categories=${CATEGORIES}
@@ -93,10 +96,11 @@ MimeType=${MIME_TYPES}
 			${SUDO} rm -f "${BIN_PATH}/${1}"
 			echo "#!/usr/bin/env bash
 ${BIN_PATH}/winapps ${1} $@
-" |${SUDO} tee "${BIN_PATH}/${1}" > /dev/null
-			${SUDO} chmod a+x "${BIN_PATH}/${1}"
-		fi
-		echo " Finished."
+" | ${SUDO} tee "${BIN_PATH}/${1}" >/dev/null
+		${SUDO} chmod a+x "${BIN_PATH}/${1}"
+	fi
+	echo " Finished."
+	ICON=""
 }
 
 function waConfigureApps() {
@@ -217,7 +221,7 @@ Name=Windows
 Exec=${BIN_PATH}/winapps windows %F
 Terminal=false
 Type=Application
-Icon=${SYS_PATH}/icons/windows.svg
+Icon=distributor-logo-windows
 StartupWMClass=Micorosoft Windows
 Comment=Micorosoft Windows
 Categories=Windows


### PR DESCRIPTION
Some iconpacks like Papyrus do come with their own icons for applications that are seemingly also just windows only. It is almost always preferrable to use the iconpack instead of the own svgs. 

I added an ICON field to the app-info where one can point to the icon-name. 