### PR TITLE
Enhance VM Detection and Improve FreeRDP Command Handling

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -65,8 +65,8 @@ if [ -z "$RDP_IP" ]; then
         echo "  sudo usermod -a -G kvm $(whoami)"
         exit
     fi
-    if virsh list | grep -vq RDPWindows; then
-        echo "RDPWindows is not running, run:"
+    if ! virsh list --state-running --name | grep -q '^RDPWindows$'; then
+        echo "RDPWindows is not running. Please run:"
         echo "  virsh start RDPWindows"
         exit
     fi

--- a/bin/winapps
+++ b/bin/winapps
@@ -90,17 +90,58 @@ if [[ -n "$RDP_FLAGS" ]]; then
     FREERDP_COMMAND="$FREERDP_COMMAND $RDP_FLAGS"
 fi
 
-if [ "$1" = "windows" ]; then
-    dprint "WINDOWS"
-    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+dynamic-resolution" "+auto-reconnect" "+home-drive" "/wm-class:\"Microsoft Windows\"" "/v:${RDP_IP}")
-    "${COMMAND[@]}" 1>/dev/null 2>&1 &
-elif [ "$1" = "check" ]; then
+if [ "$1" = "check" ]; then
+    # Open File Explorer
     dprint "CHECK"
-    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/app:program:explorer.exe" "/v:${RDP_IP}")
+    COMMAND=(
+        "${FREERDP_COMMAND}"
+        "/d:${RDP_DOMAIN}"
+        "/u:${RDP_USER}"
+        "/p:${RDP_PASS}"
+        "/scale:${RDP_SCALE}"
+        "+auto-reconnect"
+        "+home-drive"
+        "-wallpaper"
+        "+dynamic-resolution"
+        "${MULTI_FLAG}"
+        "/app:program:explorer.exe"
+        "/v:${RDP_IP}"
+    )
     "${COMMAND[@]}"
+elif [ "$1" = "windows" ]; then
+    # Open Virtual Machine
+    dprint "WINDOWS"
+    COMMAND=(
+        "${FREERDP_COMMAND}"
+        "/d:${RDP_DOMAIN}"
+        "/u:${RDP_USER}"
+        "/p:${RDP_PASS}"
+        "/scale:${RDP_SCALE}"
+        "+dynamic-resolution"
+        "+auto-reconnect"
+        "+home-drive"
+        "/wm-class:\"Microsoft Windows\""
+        "/v:${RDP_IP}"
+    )
+    # Run the command in the background, redirecting both stdout and stderr to /dev/null
+    "${COMMAND[@]}" 1>/dev/null 2>&1 &
 elif [ "$1" = "manual" ]; then
+    # Open Specified Application
     dprint "MANUAL:${2}"
-    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+home-drive" "+dynamic-resolution" "${MULTI_FLAG}" "/app:program:${2}" "/v:${RDP_IP}")
+    COMMAND=(
+        "${FREERDP_COMMAND}"
+        "/d:${RDP_DOMAIN}"
+        "/u:${RDP_USER}"
+        "/p:${RDP_PASS}"
+        "/scale:${RDP_SCALE}"
+        "+auto-reconnect"
+        "+home-drive"
+        "+dynamic-resolution"
+        "${MULTI_FLAG}"
+        "/app:program:${2}"
+        "/v:${RDP_IP}"
+    )
+    # Run the command in the background, redirecting both stdout and stderr to /dev/null
     "${COMMAND[@]}" 1>/dev/null 2>&1 &
 elif [ "$1" != "install" ]; then
     dprint "DIR:${DIR}"
@@ -125,10 +166,42 @@ elif [ "$1" != "install" ]; then
         FILE=$(echo "$2" | sed 's|'"$HOME"'|\\\\tsclient\\home|;s|/|\\|g;s|\\|\\\\|g')
         dprint "FILE:${FILE}"
         # shellcheck disable=SC2140
-        COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+clipboard" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/wm-class:${FULL_NAME}" "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME},cmd:\"${FILE}\"" "/v:${RDP_IP}")
-        "${COMMAND[@]}" 1>/dev/null 2>&1 &
+        COMMAND=(
+            "${FREERDP_COMMAND}"
+            "/d:${RDP_DOMAIN}"
+            "/u:${RDP_USER}"
+            "/p:${RDP_PASS}"
+            "/scale:${RDP_SCALE}"
+            "+auto-reconnect"
+            "+clipboard"
+            "+home-drive"
+            "-wallpaper"
+            "+dynamic-resolution"
+            "${MULTI_FLAG}"
+            "/wm-class:${FULL_NAME}"
+            "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME},cmd:\"${FILE}\""
+            "/v:${RDP_IP}"
+        )
+        # Run the command in the background, redirecting both stdout and stderr to /dev/null
+        echo "${COMMAND[@]}" #1>/dev/null 2>&1 &
     else
-        COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+clipboard" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/wm-class:${FULL_NAME}" "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME}" "/v:${RDP_IP}")
+        COMMAND=(
+            "${FREERDP_COMMAND}"
+            "/d:${RDP_DOMAIN}"
+            "/u:${RDP_USER}"
+            "/p:${RDP_PASS}"
+            "/scale:${RDP_SCALE}"
+            "+auto-reconnect"
+            "+clipboard"
+            "+home-drive"
+            "-wallpaper"
+            "+dynamic-resolution"
+            "${MULTI_FLAG}"
+            "/wm-class:${FULL_NAME}"
+            "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME}"
+            "/v:${RDP_IP}"
+        )
+        # Run the command in the background, redirecting both stdout and stderr to /dev/null
         "${COMMAND[@]}" 1>/dev/null 2>&1 &
     fi
 fi

--- a/bin/winapps
+++ b/bin/winapps
@@ -4,6 +4,7 @@ if [ ! -f "$HOME/.config/winapps/winapps.conf" ] && [ ! -f "$HOME/.winapps" ]; t
     echo "You need to create a ~/.config/winapps/winapps.conf configuration. Exiting..."
     exit
 fi
+
 DIR="$(dirname "$(readlink -f "$0")")"
 RUN="$(date)-$RANDOM"
 
@@ -72,7 +73,6 @@ if [ -z "$RDP_IP" ]; then
     fi
     RDP_IP=$(virsh net-dhcp-leases default | grep RDPWindows | awk '{print $5}')
     RDP_IP=${RDP_IP%%\/*}
-
 fi
 
 dprint "1:$1"
@@ -86,18 +86,23 @@ if [ "$MULTIMON" = "true" ]; then
     MULTI_FLAG="/multimon"
 fi
 
+# Append additional flags or parameters to FreeRDP
 if [[ -n "$RDP_FLAGS" ]]; then
     FREERDP_COMMAND="$FREERDP_COMMAND $RDP_FLAGS"
 fi
 
 if [ "$1" = "windows" ]; then
-    $FREERDP_COMMAND /d:"$RDP_DOMAIN" /u:"$RDP_USER" /p:"$RDP_PASS" /scale:$RDP_SCALE +dynamic-resolution +auto-reconnect +home-drive /wm-class:"Microsoft Windows" /v:"$RDP_IP" 1>/dev/null 2>&1 &
+    dprint "WINDOWS"
+    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+dynamic-resolution" "+auto-reconnect" "+home-drive" "/wm-class:\"Microsoft Windows\"" "/v:${RDP_IP}")
+    "${COMMAND[@]}" 1>/dev/null 2>&1 &
 elif [ "$1" = "check" ]; then
     dprint "CHECK"
-    $FREERDP_COMMAND /d:"$RDP_DOMAIN" /u:"$RDP_USER" /p:"$RDP_PASS" /scale:$RDP_SCALE +auto-reconnect +home-drive -wallpaper +dynamic-resolution $MULTI_FLAG /app:program:"explorer.exe" /v:"$RDP_IP"
+    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/app:program:explorer.exe" "/v:${RDP_IP}")
+    "${COMMAND[@]}"
 elif [ "$1" = "manual" ]; then
-    dprint "MANUAL:$2"
-    $FREERDP_COMMAND /d:"$RDP_DOMAIN" /u:"$RDP_USER" /p:"$RDP_PASS" /scale:$RDP_SCALE +auto-reconnect +home-drive +dynamic-resolution $MULTI_FLAG /app:program:"$2" /v:"$RDP_IP" 1>/dev/null 2>&1 &
+    dprint "MANUAL:${2}"
+    COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+home-drive" "+dynamic-resolution" "${MULTI_FLAG}" "/app:program:${2}" "/v:${RDP_IP}")
+    "${COMMAND[@]}" 1>/dev/null 2>&1 &
 elif [ "$1" != "install" ]; then
     dprint "DIR:${DIR}"
     if [ -e "${DIR}/../apps/$1/info" ]; then
@@ -121,9 +126,11 @@ elif [ "$1" != "install" ]; then
         FILE=$(echo "$2" | sed 's|'"$HOME"'|\\\\tsclient\\home|;s|/|\\|g;s|\\|\\\\|g')
         dprint "FILE:${FILE}"
         # shellcheck disable=SC2140
-        $FREERDP_COMMAND /d:"$RDP_DOMAIN" /u:"$RDP_USER" /p:"$RDP_PASS" /scale:$RDP_SCALE +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution $MULTI_FLAG /wm-class:"$FULL_NAME" /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:"$FULL_NAME",cmd:"\"$FILE\"" /v:"$RDP_IP" 1>/dev/null 2>&1 &
+        COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+clipboard" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/wm-class:${FULL_NAME}" "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME},cmd:\"${FILE}\"" "/v:${RDP_IP}")
+        "${COMMAND[@]}" 1>/dev/null 2>&1 &
     else
-        $FREERDP_COMMAND /d:"$RDP_DOMAIN" /u:"$RDP_USER" /p:"$RDP_PASS" /scale:$RDP_SCALE +auto-reconnect +clipboard +home-drive -wallpaper +dynamic-resolution $MULTI_FLAG /wm-class:"$FULL_NAME" /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:"$FULL_NAME" /v:"$RDP_IP" 1>/dev/null 2>&1 &
+        COMMAND=("${FREERDP_COMMAND}" "/d:${RDP_DOMAIN}" "/u:${RDP_USER}" "/p:${RDP_PASS}" "/scale:${RDP_SCALE}" "+auto-reconnect" "+clipboard" "+home-drive" "-wallpaper" "+dynamic-resolution" "${MULTI_FLAG}" "/wm-class:${FULL_NAME}" "/app:program:${WIN_EXECUTABLE},icon:${ICON},name:${FULL_NAME}" "/v:${RDP_IP}")
+        "${COMMAND[@]}" 1>/dev/null 2>&1 &
     fi
 fi
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -71,8 +71,7 @@ if [ -z "$RDP_IP" ]; then
         echo "  virsh start RDPWindows"
         exit
     fi
-    RDP_IP=$(virsh net-dhcp-leases default | grep RDPWindows | awk '{print $5}')
-    RDP_IP=${RDP_IP%%\/*}
+    RDP_IP=$(virsh net-dhcp-leases default | grep "RDPWindows" | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}')
 fi
 
 dprint "1:$1"


### PR DESCRIPTION
1. Improved detection of running VMs.
    - Replaced `virsh list` with `virsh list --state-running --name` to directly filter for running VMs by name.
    - Updated `grep` command to `grep -q '^RDPWindows$'` for precise matching of the VM name using a regular expression.
2. Convert FreeRDP command to array format for improved readability and straightforward modification.
3. Extract VM IPv4 address using a regular expression.