### PR TITLE
WinApps _requires_ FreeRDP version 3+, which is not clear from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ If you already have a virtual machine or server you wish to use with WinApps, yo
 To get things going, use:
 
 ```bash
-sudo apt install -y freerdp2-x11
+sudo apt install -y freerdp3-x11
 git clone https://github.com/winapps-org/winapps.git
 cd winapps
 ```
 
 > [!note]
-> Ideally grab freerdp 3.0.0 or later, especially if you're having issues.
-> You can find nightly builds here: https://github.com/FreeRDP/FreeRDP/wiki/Prebuilds
+> Requires FreeRDP 3.0.0 or later.
+> If not included in your distribution, you can download the Flatpak from here: https://github.com/FreeRDP/FreeRDP/wiki/Prebuilds
 
 ### Step 3: Creating your WinApps configuration file
 


### PR DESCRIPTION
The flags used when calling `$FREERDP_COMMAND` are not compatible with FreeRDP v2.  Namely v2 uses `/app: ...` and `/app-cmd ...` instead of `/app:alias:...,cmd:...` syntax used in winapps.