### PR TITLE
Added documentation for configuring `QEMU Guest Agent`

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,7 +2,7 @@
 Although WinApps supports using `QEMU+KVM+libvirt` as a backend for running Windows virtual machines, it is recommended to use `Docker` or `Podman`. These backends automate the setup process, eliminating the need for manual configuration and optimisation of the Windows virtual machine.
 
 > [!IMPORTANT]
-Running a Windows virtual machine using `Docker` or `Podman` as a backend is only possible on GNU/Linux systems. This is due to the necessity of kernel interfaces, such as the KVM hypervisor, for achieving acceptable performance. The performance of the virtual machine can vary based on the version of the Linux kernel, with newer releases generally offering better performance.
+> Running a Windows virtual machine using `Docker` or `Podman` as a backend is only possible on GNU/Linux systems. This is due to the necessity of kernel interfaces, such as the KVM hypervisor, for achieving acceptable performance. The performance of the virtual machine can vary based on the version of the Linux kernel, with newer releases generally offering better performance.
 
 > [!IMPORTANT]
 > WinApps does NOT officially support versions of Windows prior to Windows 10. Despite this, it may be possible to achieve a successful installation with some additional experimentation. If you find a way to achieve this, please share your solution through a pull request for the benefit of other users.
@@ -12,9 +12,12 @@ Running a Windows virtual machine using `Docker` or `Podman` as a backend is onl
 You can find a guide for installing `Docker Engine` [here](https://docs.docker.com/engine/install/).
 
 ### Setup `Docker` Container
-WinApps utilises `docker compose` to configure Windows VMs. A suitable [`compose.yaml`](https://github.com/winapps-org/winapps/blob/main/compose.yaml) file is included in the root directory of the WinApps repository.
+WinApps utilises `docker compose` to configure Windows VMs.
 
-Prior to initiating the installation, you can modify the RAM and number of CPU cores available to the Windows VM by changing `RAM_SIZE` and `CPU_CORES` within `compose.yaml`.
+> [!IMPORTANT]
+> The [`compose.yaml`](https://github.com/winapps-org/winapps/blob/main/compose.yaml) file located within the root directory of the WinApps repository must be manually copied to `~/.config/winapps/compose.yaml`.
+
+Prior to installing Windows, you can modify the RAM and number of CPU cores available to the Windows VM by changing `RAM_SIZE` and `CPU_CORES` within `compose.yaml`.
 
 It is also possible to specify the version of Windows you wish to install within `compose.yaml` by modifying `VERSION`.
 
@@ -24,9 +27,9 @@ It is also possible to specify the version of Windows you wish to install within
 Please refer to the [original GitHub repository](https://github.com/dockur/windows) for more information on additional configuration options.
 
 ### Installing Windows
-After navigating into the cloned WinApps repository, you can initiate the Windows installation using `docker compose`.
+You can initiate the Windows installation using `docker compose`.
 ```bash
-docker compose up
+docker compose --file ~/.config/winapps/compose.yaml up
 ```
 
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
@@ -34,22 +37,31 @@ You can then access the Windows virtual machine via a VNC connection to complete
 ### Installing WinApps
 `Docker` simplifies the WinApps installation process by eliminating the need for any additional configuration of the Windows virtual machine. Once the Windows virtual machine is up and running, you can directly launch the WinApps installer, which should automatically detect and interface with Windows.
 
+> [!NOTE]
+> Since no Windows user password is set by default, Windows may automatically log in, which may cause the WinApps installation to fail due to complications establishing an RDP connection. To avoid this issue, please use the VNC connection to ensure that the Windows user is logged out before starting the WinApps installation.
+
 ```bash
 ./installer.sh
 ```
 
-### Subsequent Use
+### Changing `compose.yaml`
+Changes require the Windows virtual machine to be removed and re-created using the updated `compose.yaml`. This should __NOT__ affect your data.
+
 ```bash
-docker compose start # Power on the Windows VM
-docker compose pause # Pause the Windows VM
-docker compose unpause # Resume the Windows VM
-docker compose restart # Restart the Windows VM
-docker compose stop # Gracefully shut down the Windows VM
-docker compose kill # Force shut down the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml down # Stop and remove the existing Windows virtual machine.
+rm ~/.config/freerdp/server/127.0.0.1_3389.pem # Remove the existing FreeRDP certificate (a new certificate will be created automatically when connecting to the new virtual machine for the first time).
+docker compose --file ~/.config/winapps/compose.yaml up # Re-create the virtual machine with the updated configuration.
 ```
 
-> [!NOTE]
-> The above `docker compose` commands must be run within the same directory containing `compose.yaml`.
+### Subsequent Use
+```bash
+docker compose --file ~/.config/winapps/compose.yaml start # Power on the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml pause # Pause the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml unpause # Resume the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml restart # Restart the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml stop # Gracefully shut down the Windows VM
+docker compose --file ~/.config/winapps/compose.yaml kill # Force shut down the Windows VM
+```
 
 ## `Podman`
 ### Installation
@@ -63,9 +75,9 @@ Please follow the [`docker` instructions](#setup-docker-container).
 > Ensure `WAFLAVOR` is set to `"podman"` in `~/.config/winapps/winapps.conf`.
 
 ### Installing Windows
-After navigating into the cloned WinApps repository, you can initiate the Windows installation using `podman-compose`.
+You can initiate the Windows installation using `podman-compose`.
 ```bash
-podman-compose up
+podman-compose --file ~/.config/winapps/compose.yaml up
 ```
 
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
@@ -73,15 +85,15 @@ You can then access the Windows virtual machine via a VNC connection to complete
 ### Installing WinApps
 Please follow the [`docker` instructions](#installing-winapps).
 
+### Changing `compose.yaml`
+Please follow the [`docker` instructions](#changing-composeyaml).
+
 ### Subsequent Use
 ```bash
-podman-compose start # Power on the Windows VM
-podman-compose pause # Pause the Windows VM
-podman-compose unpause # Resume the Windows VM
-podman-compose restart # Restart the Windows VM
-podman-compose stop # Gracefully shut down the Windows VM
-podman-compose kill # Force shut down the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml start # Power on the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml pause # Pause the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml unpause # Resume the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml restart # Restart the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml stop # Gracefully shut down the Windows VM
+podman-compose --file ~/.config/winapps/compose.yaml kill # Force shut down the Windows VM
 ```
-
-> [!NOTE]
-> The above `podman-compose` commands must be run within the same directory containing `compose.yaml`.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ Although WinApps supports using `QEMU+KVM+libvirt` as a backend for running Wind
 > Running a Windows virtual machine using `Docker` or `Podman` as a backend is only possible on GNU/Linux systems. This is due to the necessity of kernel interfaces, such as the KVM hypervisor, for achieving acceptable performance. The performance of the virtual machine can vary based on the version of the Linux kernel, with newer releases generally offering better performance.
 
 > [!IMPORTANT]
-> WinApps does NOT officially support versions of Windows prior to Windows 10. Despite this, it may be possible to achieve a successful installation with some additional experimentation. If you find a way to achieve this, please share your solution through a pull request for the benefit of other users.
+> WinApps does __NOT__ officially support versions of Windows prior to Windows 10. Despite this, it may be possible to achieve a successful installation with some additional experimentation. If you find a way to achieve this, please share your solution through a pull request for the benefit of other users.
 
 ## `Docker`
 ### Installation

--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -38,8 +38,8 @@ Together, these components form a powerful and flexible virtualization stack, wi
 > You can read more about `VirtIO` [here](https://wiki.libvirt.org/Virtio.html).
 
 ## Creating a Windows VM
-
-> [!NOTE] If you are an expert user, you may wish to:
+> [!NOTE]
+> If you are an expert user, you may wish to:
 > - [Define a Windows virtual machine from an existing `.XML` file](#defining-windows-vm-from-xml)
 > - [Configure Rootless `libvirt`](#configuring-rootless-libvirt)
 

--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -26,7 +26,12 @@ Together, these components form a powerful and flexible virtualization stack, wi
     sudo emerge app-emulation/virt-manager # Gentoo Linux
     ```
 
-3. Install `QEMU Guest Agent`.
+3. Configure `libvirt` to use the 'system' URI by adding the line `LIBVIRT_DEFAULT_URI="qemu:///system"` to your preferred shell profile file.
+    ```bash
+    echo "export LIBVIRT_DEFAULT_URI=\"qemu:///system\"" >> ~/.bashrc
+    ```
+
+4. Install `QEMU Guest Agent`.
     ```bash
     sudo apt install qemu-guest-agent # Debian/Ubuntu
     sudo dnf install qemu-guest-agent # Fedora/RHEL
@@ -36,12 +41,12 @@ Together, these components form a powerful and flexible virtualization stack, wi
     sudo systemctl start qemu-guest-agent
     ```
 
-4. Download a [Windows 10](https://www.microsoft.com/software-download/windows10ISO) or [Windows 11](https://www.microsoft.com/software-download/windows11) installation `.ISO` image.
+5. Download a [Windows 10](https://www.microsoft.com/software-download/windows10ISO) or [Windows 11](https://www.microsoft.com/software-download/windows11) installation `.ISO` image.
 
 > [!IMPORTANT]
 > 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will NOT suffice.
 
-5. Download [VirtIO drivers](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso) for the Windows virtual machine.
+6. Download [VirtIO drivers](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso) for the Windows virtual machine.
 
 > [!NOTE]
 > VirtIO drivers enhance system performance and minimize overhead by enabling the Windows virtual machine to use specialised network and disk device drivers. These drivers are aware that they are operating inside a virtual machine, and cooperate with the hypervisor. This approach eliminates the need for the hypervisor to emulate physical hardware devices, which is a computationally expensive process. This setup allows guests to achieve high-performance network and disk operations, leveraging the benefits of paravirtualisation.

--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -36,12 +36,12 @@ Together, these components form a powerful and flexible virtualization stack, wi
     sudo systemctl start qemu-guest-agent
     ```
 
-3. Download a [Windows 10](https://www.microsoft.com/software-download/windows10ISO) or [Windows 11](https://www.microsoft.com/software-download/windows11) installation `.ISO` image.
+4. Download a [Windows 10](https://www.microsoft.com/software-download/windows10ISO) or [Windows 11](https://www.microsoft.com/software-download/windows11) installation `.ISO` image.
 
 > [!IMPORTANT]
 > 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will NOT suffice.
 
-4. Download [VirtIO drivers](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso) for the Windows virtual machine.
+5. Download [VirtIO drivers](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso) for the Windows virtual machine.
 
 > [!NOTE]
 > VirtIO drivers enhance system performance and minimize overhead by enabling the Windows virtual machine to use specialised network and disk device drivers. These drivers are aware that they are operating inside a virtual machine, and cooperate with the hypervisor. This approach eliminates the need for the hypervisor to emulate physical hardware devices, which is a computationally expensive process. This setup allows guests to achieve high-performance network and disk operations, leveraging the benefits of paravirtualisation.

--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -41,6 +41,10 @@ Together, these components form a powerful and flexible virtualization stack, wi
     sudo systemctl start qemu-guest-agent
     ```
 
+> [!NOTE]
+> `QEMU Guest Agent` is a helper daemon used to exchange information and commands between host and guest operating systems.
+> You can read more about `QEMU Guest Agent` [here](https://pve.proxmox.com/wiki/Qemu-guest-agent).
+
 5. Download a [Windows 10](https://www.microsoft.com/software-download/windows10ISO) or [Windows 11](https://www.microsoft.com/software-download/windows11) installation `.ISO` image.
 
 > [!IMPORTANT]

--- a/install/ExtractPrograms.ps1
+++ b/install/ExtractPrograms.ps1
@@ -212,7 +212,12 @@ Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\*" |
     Where-Object {$_."(default)" -ne $null} |
     ForEach-Object {
         $Exe = $_."(default)".Trim('"')
-        $Name = (Get-Item $Exe).VersionInfo.FileDescription.Trim() -replace "  "," "
+        $Item = Get-Item $Exe
+        if ($Item.VersionInfo.FileDescription) {
+            $Name = $Item.VersionInfo.FileDescription.Trim() -replace "  ", " "
+        } else {
+            $Name = [System.IO.Path]::GetFileNameWithoutExtension($Exe)
+        }
         $Icon = Get-Icon -Path $Exe -ToBase64
         #Get-ItemProperty $Exe -Name VersionInfo
         "NAMES+=(""$Name"")"

--- a/installer.sh
+++ b/installer.sh
@@ -1543,9 +1543,9 @@ function waUninstall() {
     done
 
     # Print caveats.
-    echo -e "\n${INFO_TEXT}Please note your WinApps configuration file was not removed.${CLEAR_TEXT}"
+    echo -e "\n${INFO_TEXT}Please note your WinApps configuration folder was not removed.${CLEAR_TEXT}"
     echo -e "${INFO_TEXT}You can remove this manually by running:${CLEAR_TEXT}"
-    echo -e "${COMMAND_TEXT}rm ${CONFIG_PATH}${CLEAR_TEXT}\n"
+    echo -e "${COMMAND_TEXT}rm $(dirname "$CONFIG_PATH")${CLEAR_TEXT}\n"
 
     # Print feedback.
     echo -e "${SUCCESS_TEXT}UNINSTALLATION COMPLETE.${CLEAR_TEXT}"


### PR DESCRIPTION
I was previously having issues where `virsh shutdown RDPWindows` would fail. Configuring `QEMU Guest Agent` allows the GNU/Linux host to properly shut down Windows instead of relying on ACPI commands. After completing the additional configuration specified in `docs/libvirt.md`, the aforementioned command now works.