### PR TITLE
Adding more file type support for Microsoft Visio

### DIFF
--- a/apps/visio-x86/info
+++ b/apps/visio-x86/info
@@ -12,4 +12,3 @@ CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
 MIME_TYPES="application/vnd.ms-visio.template.main+xml;application/vnd.ms-visio.stencil.main+xml;application/vnd.ms-visio.drawing.main+xml;application/vnd.ms-visio.stencil.macroEnabled.main+xml;application/vnd.ms-visio.drawing.macroEnabled.main+xml;application/vnd.ms-visio.template.macroEnabled.main+xml;"
-

--- a/apps/visio-x86/info
+++ b/apps/visio-x86/info
@@ -11,4 +11,5 @@ WIN_EXECUTABLE="C:\Program Files (x86)\Microsoft Office\root\Office16\VISIO.EXE"
 CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
-MIME_TYPES="application/vnd.ms-visio.drawing.main+xml;"
+MIME_TYPES="application/vnd.ms-visio.template.main+xml;application/vnd.ms-visio.stencil.main+xml;application/vnd.ms-visio.drawing.main+xml;application/vnd.ms-visio.stencil.macroEnabled.main+xml;application/vnd.ms-visio.drawing.macroEnabled.main+xml;application/vnd.ms-visio.template.macroEnabled.main+xml;"
+

--- a/apps/visio/info
+++ b/apps/visio/info
@@ -11,4 +11,4 @@ WIN_EXECUTABLE="C:\Program Files\Microsoft Office\root\Office16\VISIO.EXE"
 CATEGORIES="WinApps;Office"
 
 # GNOME mimetypes
-MIME_TYPES="application/vnd.ms-visio.drawing.main+xml;"
+MIME_TYPES="application/vnd.ms-visio.template.main+xml;application/vnd.ms-visio.stencil.main+xml;application/vnd.ms-visio.drawing.main+xml;application/vnd.ms-visio.stencil.macroEnabled.main+xml;application/vnd.ms-visio.drawing.macroEnabled.main+xml;application/vnd.ms-visio.template.macroEnabled.main+xml;"


### PR DESCRIPTION
Bit of an oversight from me in the last PR. This PR adds the mimetypes for Microsoft Visio templates and stencils along with their macro-enabled versions for a more complete experience.