### PR TITLE
Disable auto admin logon to avoid a highly insecure combination of defaults

### DIFF
--- a/oem/RDPApps.reg
+++ b/oem/RDPApps.reg
@@ -5,6 +5,6 @@ Windows Registry Editor Version 5.00
 
     [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services]
     "fAllowUnlistedRemotePrograms"=dword:00000001
-	
-	[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
+
+    [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
     "AutoAdminLogon"="0"

--- a/oem/RDPApps.reg
+++ b/oem/RDPApps.reg
@@ -5,3 +5,6 @@ Windows Registry Editor Version 5.00
 
     [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services]
     "fAllowUnlistedRemotePrograms"=dword:00000001
+	
+	[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
+    "AutoAdminLogon"="0"


### PR DESCRIPTION
PROBLEM:
The default Dockur image applies a permanent auto admin login registry setting on container setup. 

This is a MASSIVE security vulnerability likely added for convenience, but when used in combination with the WinApps recommended default compose file creates a scenario where the Windows container is permanently available (and with interactive  admin privs) to any network the host is connected to!

SOLUTION:
A registry change added during the OEM setup install.bat script to disable auto admin logon 
```
[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
 "AutoAdminLogon"="0"
```
 or to change the default suggested WinApps docker compose to
```
      - 127.0.0.1:8006:8006
      - 127.0.0.1:3389:3389/tcp
      - 127.0.0,1:3389:3389/udp  
```
or
A halfway gentler option (and for those who might need a few re-boots for unattended setups) could also be to limit the total count of auto admin logins to a max of 2  :
```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
 "AutoLogonCount"=dword:00000001' 
```
(yes =dword:00000001=2, this is an MS bug and you cant make this lower than 2)

In my testing, blocking the auto admin logon does not seem to impact any of the Windows container setup
