### PR TITLE
Add Support for Microsoft Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ Contributing to the list of supported applications is encouraged through submiss
         </td>
     </tr>
     <tr>
+        <!-- Microsoft Project -->
+        <td>
+            <img src="apps/project/icon.svg" width="100">
+        </td>
+        <td>
+            <b>Microsoft Project</b><br>
+            (Standard/Pro 2021, Plan 3/5)<br>
+            <i><a href="https://en.m.wikipedia.org/wiki/File:Microsoft_Project_(2019–present).svg">Icon</a> in the Public Domain.</i>
+        </td>
         <!-- PowerShell -->
         <td>
             <img src="apps/powershell/icon.svg" width="100">
@@ -242,6 +251,7 @@ Contributing to the list of supported applications is encouraged through submiss
             <b>PowerShell</b><br>
             <i><a href="https://iconduck.com/icons/102322/file-type-powershell">Icon</a> under <a href="https://iconduck.com/licenses/mit">MIT license</a>.</i>
         </td>
+        <tr>
         <!-- Windows -->
         <td>
             <img src="icons/windows.svg" width="100">

--- a/apps/project-x86/icon.svg
+++ b/apps/project-x86/icon.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
+	 style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#185C37;}
+	.st1{fill:#33C481;}
+	.st2{fill:#21A366;}
+	.st3{opacity:0.1;enable-background:new    ;}
+	.st4{opacity:0.2;enable-background:new    ;}
+	.st5{fill:url(#SVGID_1_);}
+	.st6{fill:#FFFFFF;}
+</style>
+<metadata>
+	<sfw  xmlns="&ns_sfw;">
+		<slices></slices>
+		<sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
+	</sfw>
+</metadata>
+<path class="st0" d="M60.1,54.8H24.4c-1.5,0-2.7-1.2-2.7-2.7V36.5l13.7-6.8l17.1,6.8h7.6c1.5,0,2.7,1.2,2.7,2.7v12.9
+	C62.8,53.6,61.6,54.8,60.1,54.8z"/>
+<path class="st1" d="M42.2,18.3l-16,5.7L8,18.3V2.7C8,1.2,9.2,0,10.7,0h28.9c1.5,0,2.7,1.2,2.7,2.7L42.2,18.3L42.2,18.3z"/>
+<path class="st2" d="M8,18.3h41.8c1.5,0,2.7,1.2,2.7,2.7v15.6H10.7c-1.5,0-2.7-1.2-2.7-2.7V18.3z"/>
+<path class="st3" d="M21.7,46.8h8.7c1.3,0,2.4-0.9,2.6-2.2V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11V46.8z"/>
+<path class="st4" d="M30.4,45.7c2.1,0,3.8-1.7,3.8-3.8V14.1c0-2.1-1.7-3.8-3.8-3.8H8v23.6c0,1.5,1.2,2.7,2.7,2.7h11v9.1
+	C21.7,45.7,30.4,45.7,30.4,45.7z"/>
+<path class="st4" d="M30.4,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
+	C21.7,44.5,30.4,44.5,30.4,44.5z"/>
+<path class="st3" d="M29.3,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
+	C21.7,44.5,29.3,44.5,29.3,44.5z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.5643" y1="2105.324" x2="26.4033" y2="2141.4199" gradientTransform="matrix(1 0 0 1 0 -2096)">
+	<stop  offset="0" style="stop-color:#18884F"/>
+	<stop  offset="0.5" style="stop-color:#117E43"/>
+	<stop  offset="1" style="stop-color:#0B6631"/>
+</linearGradient>
+<path class="st5" d="M2.7,11.4h26.6c1.5,0,2.7,1.2,2.7,2.7v26.6c0,1.5-1.2,2.7-2.7,2.7H2.7c-1.5,0-2.7-1.2-2.7-2.7V14.1
+	C0,12.6,1.2,11.4,2.7,11.4z"/>
+<path class="st6" d="M16.5,18.5c1.7-0.1,3.4,0.4,4.7,1.4c1.1,1.1,1.7,2.6,1.6,4.1c0,1.1-0.3,2.1-0.8,3.1c-0.6,0.9-1.4,1.6-2.3,2.1
+	c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
+	c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
+</svg>

--- a/apps/project-x86/icon.svg
+++ b/apps/project-x86/icon.svg
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
-	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
-	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
-	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
-	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
-	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
-	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
-	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
-	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+    <!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+    <!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+    <!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+    <!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+    <!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+    <!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+    <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+    <!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
 ]>
 <svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
-	 style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
+     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
+     style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#185C37;}
-	.st1{fill:#33C481;}
-	.st2{fill:#21A366;}
-	.st3{opacity:0.1;enable-background:new    ;}
-	.st4{opacity:0.2;enable-background:new    ;}
-	.st5{fill:url(#SVGID_1_);}
-	.st6{fill:#FFFFFF;}
+    .st0{fill:#185C37;}
+    .st1{fill:#33C481;}
+    .st2{fill:#21A366;}
+    .st3{opacity:0.1;enable-background:new    ;}
+    .st4{opacity:0.2;enable-background:new    ;}
+    .st5{fill:url(#SVGID_1_);}
+    .st6{fill:#FFFFFF;}
 </style>
 <metadata>
-	<sfw  xmlns="&ns_sfw;">
-		<slices></slices>
-		<sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
-	</sfw>
+    <sfw  xmlns="&ns_sfw;">
+        <slices></slices>
+        <sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
+    </sfw>
 </metadata>
 <path class="st0" d="M60.1,54.8H24.4c-1.5,0-2.7-1.2-2.7-2.7V36.5l13.7-6.8l17.1,6.8h7.6c1.5,0,2.7,1.2,2.7,2.7v12.9
-	C62.8,53.6,61.6,54.8,60.1,54.8z"/>
+    C62.8,53.6,61.6,54.8,60.1,54.8z"/>
 <path class="st1" d="M42.2,18.3l-16,5.7L8,18.3V2.7C8,1.2,9.2,0,10.7,0h28.9c1.5,0,2.7,1.2,2.7,2.7L42.2,18.3L42.2,18.3z"/>
 <path class="st2" d="M8,18.3h41.8c1.5,0,2.7,1.2,2.7,2.7v15.6H10.7c-1.5,0-2.7-1.2-2.7-2.7V18.3z"/>
 <path class="st3" d="M21.7,46.8h8.7c1.3,0,2.4-0.9,2.6-2.2V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11V46.8z"/>
 <path class="st4" d="M30.4,45.7c2.1,0,3.8-1.7,3.8-3.8V14.1c0-2.1-1.7-3.8-3.8-3.8H8v23.6c0,1.5,1.2,2.7,2.7,2.7h11v9.1
-	C21.7,45.7,30.4,45.7,30.4,45.7z"/>
+    C21.7,45.7,30.4,45.7,30.4,45.7z"/>
 <path class="st4" d="M30.4,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
-	C21.7,44.5,30.4,44.5,30.4,44.5z"/>
+    C21.7,44.5,30.4,44.5,30.4,44.5z"/>
 <path class="st3" d="M29.3,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
-	C21.7,44.5,29.3,44.5,29.3,44.5z"/>
+    C21.7,44.5,29.3,44.5,29.3,44.5z"/>
 <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.5643" y1="2105.324" x2="26.4033" y2="2141.4199" gradientTransform="matrix(1 0 0 1 0 -2096)">
-	<stop  offset="0" style="stop-color:#18884F"/>
-	<stop  offset="0.5" style="stop-color:#117E43"/>
-	<stop  offset="1" style="stop-color:#0B6631"/>
+    <stop  offset="0" style="stop-color:#18884F"/>
+    <stop  offset="0.5" style="stop-color:#117E43"/>
+    <stop  offset="1" style="stop-color:#0B6631"/>
 </linearGradient>
 <path class="st5" d="M2.7,11.4h26.6c1.5,0,2.7,1.2,2.7,2.7v26.6c0,1.5-1.2,2.7-2.7,2.7H2.7c-1.5,0-2.7-1.2-2.7-2.7V14.1
-	C0,12.6,1.2,11.4,2.7,11.4z"/>
+    C0,12.6,1.2,11.4,2.7,11.4z"/>
 <path class="st6" d="M16.5,18.5c1.7-0.1,3.4,0.4,4.7,1.4c1.1,1.1,1.7,2.6,1.6,4.1c0,1.1-0.3,2.1-0.8,3.1c-0.6,0.9-1.4,1.6-2.3,2.1
-	c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
-	c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
+    c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
+    c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
 </svg>

--- a/apps/project-x86/info
+++ b/apps/project-x86/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files (x86)\Microsoft Office\root\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="WinApps;Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/vnd.ms-project;"

--- a/apps/project/icon.svg
+++ b/apps/project/icon.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
+	 style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#185C37;}
+	.st1{fill:#33C481;}
+	.st2{fill:#21A366;}
+	.st3{opacity:0.1;enable-background:new    ;}
+	.st4{opacity:0.2;enable-background:new    ;}
+	.st5{fill:url(#SVGID_1_);}
+	.st6{fill:#FFFFFF;}
+</style>
+<metadata>
+	<sfw  xmlns="&ns_sfw;">
+		<slices></slices>
+		<sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
+	</sfw>
+</metadata>
+<path class="st0" d="M60.1,54.8H24.4c-1.5,0-2.7-1.2-2.7-2.7V36.5l13.7-6.8l17.1,6.8h7.6c1.5,0,2.7,1.2,2.7,2.7v12.9
+	C62.8,53.6,61.6,54.8,60.1,54.8z"/>
+<path class="st1" d="M42.2,18.3l-16,5.7L8,18.3V2.7C8,1.2,9.2,0,10.7,0h28.9c1.5,0,2.7,1.2,2.7,2.7L42.2,18.3L42.2,18.3z"/>
+<path class="st2" d="M8,18.3h41.8c1.5,0,2.7,1.2,2.7,2.7v15.6H10.7c-1.5,0-2.7-1.2-2.7-2.7V18.3z"/>
+<path class="st3" d="M21.7,46.8h8.7c1.3,0,2.4-0.9,2.6-2.2V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11V46.8z"/>
+<path class="st4" d="M30.4,45.7c2.1,0,3.8-1.7,3.8-3.8V14.1c0-2.1-1.7-3.8-3.8-3.8H8v23.6c0,1.5,1.2,2.7,2.7,2.7h11v9.1
+	C21.7,45.7,30.4,45.7,30.4,45.7z"/>
+<path class="st4" d="M30.4,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
+	C21.7,44.5,30.4,44.5,30.4,44.5z"/>
+<path class="st3" d="M29.3,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
+	C21.7,44.5,29.3,44.5,29.3,44.5z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.5643" y1="2105.324" x2="26.4033" y2="2141.4199" gradientTransform="matrix(1 0 0 1 0 -2096)">
+	<stop  offset="0" style="stop-color:#18884F"/>
+	<stop  offset="0.5" style="stop-color:#117E43"/>
+	<stop  offset="1" style="stop-color:#0B6631"/>
+</linearGradient>
+<path class="st5" d="M2.7,11.4h26.6c1.5,0,2.7,1.2,2.7,2.7v26.6c0,1.5-1.2,2.7-2.7,2.7H2.7c-1.5,0-2.7-1.2-2.7-2.7V14.1
+	C0,12.6,1.2,11.4,2.7,11.4z"/>
+<path class="st6" d="M16.5,18.5c1.7-0.1,3.4,0.4,4.7,1.4c1.1,1.1,1.7,2.6,1.6,4.1c0,1.1-0.3,2.1-0.8,3.1c-0.6,0.9-1.4,1.6-2.3,2.1
+	c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
+	c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
+</svg>

--- a/apps/project/icon.svg
+++ b/apps/project/icon.svg
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
-	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
-	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
-	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
-	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
-	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
-	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
-	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
-	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+    <!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+    <!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+    <!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+    <!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+    <!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+    <!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+    <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+    <!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
 ]>
 <svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
-	 style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
+     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 62.8 54.8"
+     style="enable-background:new 0 0 62.8 54.8;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#185C37;}
-	.st1{fill:#33C481;}
-	.st2{fill:#21A366;}
-	.st3{opacity:0.1;enable-background:new    ;}
-	.st4{opacity:0.2;enable-background:new    ;}
-	.st5{fill:url(#SVGID_1_);}
-	.st6{fill:#FFFFFF;}
+    .st0{fill:#185C37;}
+    .st1{fill:#33C481;}
+    .st2{fill:#21A366;}
+    .st3{opacity:0.1;enable-background:new    ;}
+    .st4{opacity:0.2;enable-background:new    ;}
+    .st5{fill:url(#SVGID_1_);}
+    .st6{fill:#FFFFFF;}
 </style>
 <metadata>
-	<sfw  xmlns="&ns_sfw;">
-		<slices></slices>
-		<sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
-	</sfw>
+    <sfw  xmlns="&ns_sfw;">
+        <slices></slices>
+        <sliceSourceBounds  bottomLeftOrigin="true" height="54.8" width="62.8" x="0.5" y="4.6"></sliceSourceBounds>
+    </sfw>
 </metadata>
 <path class="st0" d="M60.1,54.8H24.4c-1.5,0-2.7-1.2-2.7-2.7V36.5l13.7-6.8l17.1,6.8h7.6c1.5,0,2.7,1.2,2.7,2.7v12.9
-	C62.8,53.6,61.6,54.8,60.1,54.8z"/>
+    C62.8,53.6,61.6,54.8,60.1,54.8z"/>
 <path class="st1" d="M42.2,18.3l-16,5.7L8,18.3V2.7C8,1.2,9.2,0,10.7,0h28.9c1.5,0,2.7,1.2,2.7,2.7L42.2,18.3L42.2,18.3z"/>
 <path class="st2" d="M8,18.3h41.8c1.5,0,2.7,1.2,2.7,2.7v15.6H10.7c-1.5,0-2.7-1.2-2.7-2.7V18.3z"/>
 <path class="st3" d="M21.7,46.8h8.7c1.3,0,2.4-0.9,2.6-2.2V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11V46.8z"/>
 <path class="st4" d="M30.4,45.7c2.1,0,3.8-1.7,3.8-3.8V14.1c0-2.1-1.7-3.8-3.8-3.8H8v23.6c0,1.5,1.2,2.7,2.7,2.7h11v9.1
-	C21.7,45.7,30.4,45.7,30.4,45.7z"/>
+    C21.7,45.7,30.4,45.7,30.4,45.7z"/>
 <path class="st4" d="M30.4,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
-	C21.7,44.5,30.4,44.5,30.4,44.5z"/>
+    C21.7,44.5,30.4,44.5,30.4,44.5z"/>
 <path class="st3" d="M29.3,44.5c1.5,0,2.7-1.2,2.7-2.6V14.1c0-1.5-1.2-2.7-2.6-2.7H8v22.4c0,1.5,1.2,2.7,2.7,2.7h11v8
-	C21.7,44.5,29.3,44.5,29.3,44.5z"/>
+    C21.7,44.5,29.3,44.5,29.3,44.5z"/>
 <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.5643" y1="2105.324" x2="26.4033" y2="2141.4199" gradientTransform="matrix(1 0 0 1 0 -2096)">
-	<stop  offset="0" style="stop-color:#18884F"/>
-	<stop  offset="0.5" style="stop-color:#117E43"/>
-	<stop  offset="1" style="stop-color:#0B6631"/>
+    <stop  offset="0" style="stop-color:#18884F"/>
+    <stop  offset="0.5" style="stop-color:#117E43"/>
+    <stop  offset="1" style="stop-color:#0B6631"/>
 </linearGradient>
 <path class="st5" d="M2.7,11.4h26.6c1.5,0,2.7,1.2,2.7,2.7v26.6c0,1.5-1.2,2.7-2.7,2.7H2.7c-1.5,0-2.7-1.2-2.7-2.7V14.1
-	C0,12.6,1.2,11.4,2.7,11.4z"/>
+    C0,12.6,1.2,11.4,2.7,11.4z"/>
 <path class="st6" d="M16.5,18.5c1.7-0.1,3.4,0.4,4.7,1.4c1.1,1.1,1.7,2.6,1.6,4.1c0,1.1-0.3,2.1-0.8,3.1c-0.6,0.9-1.4,1.6-2.3,2.1
-	c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
-	c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
+    c-1.1,0.5-2.3,0.8-3.5,0.7h-3.3v6.3H9.5V18.5H16.5z M13,27.2h2.9c0.9,0.1,1.8-0.2,2.6-0.8c0.6-0.6,0.9-1.4,0.9-2.3
+    c0-2-1.1-2.9-3.3-2.9h-3C13.1,21.2,13,27.2,13,27.2z"/>
 </svg>

--- a/apps/project/info
+++ b/apps/project/info
@@ -1,0 +1,14 @@
+# GNOME shortcut name
+NAME="Project"
+
+# Used for descriptions and window class
+FULL_NAME="Microsoft Project"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files\Microsoft Office\root\Office16\WINPROJ.EXE"
+
+# GNOME categories
+CATEGORIES="WinApps;Office"
+
+# GNOME mimetypes
+MIME_TYPES="application/vnd.ms-project;"


### PR DESCRIPTION
This PR adds installation support of Microsoft Project to WinApps, including installation info and icons. README.md is also appended with Microsoft Project.

As for the `mimetype`, it is not so easy to add support for since Linux always thinks that `.mpp` is the Musepack Audio Format. If I am able to solve this problem, I will start another PR.