### PR TITLE
Add option to use a preexisting windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ RDP_IP=""
 # - 'docker'
 # - 'podman'
 # - 'libvirt'
+# - 'manual'
 WAFLAVOR="docker"
 
 # [DISPLAY SCALING FACTOR]

--- a/bin/winapps
+++ b/bin/winapps
@@ -675,6 +675,8 @@ if [ "$WAFLAVOR" = "docker" ] || [ "$WAFLAVOR" = "podman" ]; then
 elif [ "$WAFLAVOR" = "libvirt" ]; then
     waCheckGroupMembership
     waCheckVMRunning
+elif [ "$WAFLAVOR" = "manual" ]; then
+    waCheckPortOpen
 else
     waThrowExit "$EC_INVALID_FLAVOR"
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -1493,6 +1493,9 @@ function waInstall() {
 
         # Check if the Windows VM is powered on.
         waCheckVMRunning
+    elif [ "$WAFLAVOR" = "manual" ]; then
+        # TODO do some checks for an existing windows vm
+        echo "Using existing vm"
     else
         # Display the error type.
         echo -e "${ERROR_TEXT}ERROR:${CLEAR_TEXT} ${BOLD_TEXT}INVALID WINAPPS BACKEND.${CLEAR_TEXT}"

--- a/installer.sh
+++ b/installer.sh
@@ -1494,8 +1494,7 @@ function waInstall() {
         # Check if the Windows VM is powered on.
         waCheckVMRunning
     elif [ "$WAFLAVOR" = "manual" ]; then
-        # TODO do some checks for an existing windows vm
-        echo "Using existing vm"
+        waCheckPortOpen
     else
         # Display the error type.
         echo -e "${ERROR_TEXT}ERROR:${CLEAR_TEXT} ${BOLD_TEXT}INVALID WINAPPS BACKEND.${CLEAR_TEXT}"


### PR DESCRIPTION
I made a quick test how to upgrade from my old version of winapps, while still using my existing windows vm.

Currently it fails however, and in windows I only get the popup to install an additional application.

![image](https://github.com/user-attachments/assets/e7035d5c-3b6b-4ff0-a8b1-811cb358a4f8)


Fixes https://github.com/winapps-org/winapps/issues/203

