### PR TITLE
optimize the logic for detecting the FreeRDP command

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -250,12 +250,16 @@ function waGetFreeRDPCommand() {
             if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
                 FREERDP_COMMAND="xfreerdp"
             fi
-        # Check for 'xfreerdp3'.
-        elif command -v xfreerdp3 &>/dev/null; then
-            # Check FreeRDP major version is 3 or greater.
-            FREERDP_MAJOR_VERSION=$(xfreerdp3 --version | head -n 1 | grep -o -m 1 '\b[0-9]\S*' | head -n 1 | cut -d'.' -f1)
-            if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
-                FREERDP_COMMAND="xfreerdp3"
+        fi
+
+        # Check for 'xfreerdp3' command as a fallback option.
+        if [ -z "$FREERDP_COMMAND" ]; then
+            if command -v xfreerdp3 &>/dev/null; then
+                # Check FreeRDP major version is 3 or greater.
+                FREERDP_MAJOR_VERSION=$(xfreerdp3 --version | head -n 1 | grep -o -m 1 '\b[0-9]\S*' | head -n 1 | cut -d'.' -f1)
+                if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
+                    FREERDP_COMMAND="xfreerdp3"
+                fi
             fi
         fi
 

--- a/installer.sh
+++ b/installer.sh
@@ -548,11 +548,16 @@ function waCheckInstallDependencies() {
             if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
                 FREERDP_COMMAND="xfreerdp"
             fi
-        elif command -v xfreerdp3 &>/dev/null; then
-            # Check FreeRDP major version is 3 or greater.
-            FREERDP_MAJOR_VERSION=$(xfreerdp3 --version | head -n 1 | grep -o -m 1 '\b[0-9]\S*' | head -n 1 | cut -d'.' -f1)
-            if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
-                FREERDP_COMMAND="xfreerdp3"
+        fi
+
+        # Check for xfreerdp3 command as a fallback option.
+        if [ -z "$FREERDP_COMMAND" ]; then
+            if command -v xfreerdp3 &>/dev/null; then
+                # Check FreeRDP major version is 3 or greater.
+                FREERDP_MAJOR_VERSION=$(xfreerdp3 --version | head -n 1 | grep -o -m 1 '\b[0-9]\S*' | head -n 1 | cut -d'.' -f1)
+                if [[ $FREERDP_MAJOR_VERSION =~ ^[0-9]+$ ]] && ((FREERDP_MAJOR_VERSION >= 3)); then
+                    FREERDP_COMMAND="xfreerdp3"
+                fi
             fi
         fi
 


### PR DESCRIPTION
Optimize the logic for detecting the FreeRDP command, falling back from `xfreerdp` to `xfreerdp3` to handle situations where both FreeRDP2 and FreeRDP3 are installed on the host