### PR TITLE
README.md: Rename KDE Plasma shorthand to the correct `Plasma`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center"><img align="center" width="700" src="./icons/banner_dark.svg#gh-light-mode-only"/></p>
 <hr>
 
-Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `Plasma`, `GNOME` or `XFCE`, integrated seamlessly as if they were native to the OS.
+Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `KDE Plasma`, `GNOME` or `XFCE`, integrated seamlessly as if they were native to the OS.
 
 <p align="center"><img src="./demo/demo.png" width=1000 alt="WinApps Demonstration."></p>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center"><img align="center" width="700" src="./icons/banner_dark.svg#gh-light-mode-only"/></p>
 <hr>
 
-Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `KDE`, `GNOME` or `XFCE`, integrated seamlessly as if they were native to the OS.
+Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `Plasma`, `GNOME` or `XFCE`, integrated seamlessly as if they were native to the OS.
 
 <p align="center"><img src="./demo/demo.png" width=1000 alt="WinApps Demonstration."></p>
 


### PR DESCRIPTION
Shorthand for KDE Plasma is Plasma, not KDE.  
KDE is the group, Plasma is the DE.