### PR TITLE
Fixing Uninstall Failure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,8 +38,8 @@ readonly SYS_BIN_PATH="/usr/local/bin"                  # UNIX path to 'bin' dir
 readonly USER_BIN_PATH="${HOME}/.local/bin"             # UNIX path to 'bin' directory for a '--user' WinApps installation.
 readonly USER_BIN_PATH_WIN='\\tsclient\home\.local\bin' # WINDOWS path to 'bin' directory for a '--user' WinApps installation.
 # 'SOURCE'
-readonly SYS_SOURCE_PATH="${SYS_BIN_PATH}/winapps" # UNIX path to WinApps source directory for a '--system' WinApps installation.
-readonly USER_SOURCE_PATH="${USER_BIN_PATH}/winapps" # UNIX path to WinApps source directory for a '--system' WinApps installation.
+readonly SYS_SOURCE_PATH="${SYS_BIN_PATH}/winapps-src" # UNIX path to WinApps source directory for a '--system' WinApps installation.
+readonly USER_SOURCE_PATH="${USER_BIN_PATH}/winapps-src" # UNIX path to WinApps source directory for a '--system' WinApps installation.
 # 'APP'
 readonly SYS_APP_PATH="/usr/share/applications"                        # UNIX path to 'applications' directory for a '--system' WinApps installation.
 readonly USER_APP_PATH="${HOME}/.local/share/applications"             # UNIX path to 'applications' directory for a '--user' WinApps installation.
@@ -1673,7 +1673,7 @@ function waUninstall() {
     local BASH_SCRIPT_NAME=""         # Stores the name of the application.
 
     # Remove the 'WinApps' bash scripts.
-    $SUDO rm -rf "${BIN_PATH}/winapps"
+    $SUDO rm -f "${BIN_PATH}/winapps"
     $SUDO rm -f "${BIN_PATH}/winapps-setup"
 
     # Remove WinApps configuration data, temporary files and logs.

--- a/setup.sh
+++ b/setup.sh
@@ -1673,7 +1673,7 @@ function waUninstall() {
     local BASH_SCRIPT_NAME=""         # Stores the name of the application.
 
     # Remove the 'WinApps' bash scripts.
-    $SUDO rm -f "${BIN_PATH}/winapps"
+    $SUDO rm -rf "${BIN_PATH}/winapps"
     $SUDO rm -f "${BIN_PATH}/winapps-setup"
 
     # Remove WinApps configuration data, temporary files and logs.


### PR DESCRIPTION
As of the latest git pull, the uninstall option fails to complete with the following error:

![image](https://github.com/user-attachments/assets/264aaddb-e0ae-470b-96ac-25bc1e1a31de)

This is because the setup script was trying to remove the `winapps` directory on `$BIN_PATH` as a file in line 1676:
`$SUDO rm -f "${BIN_PATH}/winapps"`

Adding the recursive `-r` flag fixes this issue and uninstalls are successful.