### PR TITLE
Support old windows versions

### DIFF
--- a/install/ExtractPrograms.ps1
+++ b/install/ExtractPrograms.ps1
@@ -329,6 +329,8 @@ Write-Output 'ICONS=()'
 
 # Search for installed applications.
 AppSearchWinReg     # Windows Registry
-AppSearchUWP        # Universal Windows Platform
+if (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue){
+    AppSearchUWP        # Universal Windows Platform
+}
 AppSearchChocolatey # Chocolatey Package Manager
 AppSearchScoop      # Scoop Package Manager

--- a/setup.sh
+++ b/setup.sh
@@ -1621,8 +1621,8 @@ function waInstall() {
     waFindInstalled
 
     # Install the WinApps bash scripts.
-    $SUDO ln -s "./bin/winapps" "${BIN_PATH}/winapps"
-    $SUDO ln -s "./setup.sh" "${BIN_PATH}/winapps-setup"
+    $SUDO ln -sf "${SOURCE_PATH}/bin/winapps" "${BIN_PATH}/winapps"
+    $SUDO ln -sf "${SOURCE_PATH}/setup.sh" "${BIN_PATH}/winapps-setup"
 
     # Configure the Windows RDP session application launcher.
     waConfigureWindows


### PR DESCRIPTION
Added a test to not error out when the Appx cmdlets are not available (like in the windows 7 box i am using). I had some install issues with creating the bin links so I added "-f" and the absolute path.