### PR TITLE
switch managment of /sound /microphone & /cert:tofu to the winapps config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ WAFLAVOR="docker"
 RDP_SCALE="100"
 
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]
-# DEFAULT VALUE: '' (BLANK)
+# DEFAULT VALUE: '/cert:tofu /sound /microphone'
 # VALID VALUES: See https://github.com/awakecoding/FreeRDP-Manuals/blob/master/User/FreeRDP-User-Manual.markdown
-RDP_FLAGS=""
+RDP_FLAGS="/cert:tofu /sound /microphone"
 
 # [MULTIPLE MONITORS]
 # NOTES:

--- a/bin/winapps
+++ b/bin/winapps
@@ -513,8 +513,8 @@ function waRunCommand() {
             +dynamic-resolution \
             +auto-reconnect \
             +home-drive \
-            /sound \
-            /microphone \
+            +clipboard \
+            -wallpaper \
             /wm-class:"Microsoft Windows" \
             /t:"Windows RDP Session [$RDP_IP]" \
             /v:"$RDP_IP" &>/dev/null &
@@ -525,18 +525,15 @@ function waRunCommand() {
         # Open specified application.
         dprint "MANUAL: ${2}"
         $FREERDP_COMMAND \
-            /cert:tofu \
             /d:"$RDP_DOMAIN" \
             /u:"$RDP_USER" \
             /p:"$RDP_PASS" \
             /scale:"$RDP_SCALE" \
-            +auto-reconnect \
-            +clipboard \
-            +home-drive \
-            /sound \
-            /microphone \
-            -wallpaper \
             +dynamic-resolution \
+            +auto-reconnect \
+            +home-drive \
+            +clipboard \
+            -wallpaper \
             "$MULTI_FLAG" \
             /app:program:"$2" \
             /v:"$RDP_IP" &>/dev/null &
@@ -569,13 +566,11 @@ function waRunCommand() {
                 /u:"$RDP_USER" \
                 /p:"$RDP_PASS" \
                 /scale:"$RDP_SCALE" \
-                +auto-reconnect \
-                +clipboard \
-                +home-drive \
-                /sound \
-                /microphone \
-                -wallpaper \
                 +dynamic-resolution \
+                +auto-reconnect \
+                +home-drive \
+                +clipboard \
+                -wallpaper \
                 "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:"$FULL_NAME" \
@@ -592,18 +587,15 @@ function waRunCommand() {
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
 
             $FREERDP_COMMAND \
-                /cert:tofu \
                 /d:"$RDP_DOMAIN" \
                 /u:"$RDP_USER" \
                 /p:"$RDP_PASS" \
                 /scale:"$RDP_SCALE" \
-                +auto-reconnect \
-                +clipboard \
-                +home-drive \
-                /sound \
-                /microphone \
-                -wallpaper \
                 +dynamic-resolution \
+                +auto-reconnect \
+                +home-drive \
+                +clipboard \
+                -wallpaper \
                 "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:$"FULL_NAME",cmd:\""$FILE_PATH"\" \


### PR DESCRIPTION
As requested (and tested on debian 12). 
The default config file now the place to configure sound, mic and tofu. The default config file in readme now reads:
 `RDP_FLAGS="/cert:tofu /sound /microphone"`

I have also harmonised the common RDP options that apply when $FREERDP_COMMAND is called. The existing script was a little inconsistent across each of the 4 ways it could be called. Now the defauts that apply uniformly are:
```
+dynamic-resolution 
+auto-reconnect 
+home-drive 
+clipboard 
-wallpaper 
```