### PR TITLE
Fix keyboard-layout being changed to US on RDP connection

### DIFF
--- a/oem/RDPApps.reg
+++ b/oem/RDPApps.reg
@@ -8,3 +8,6 @@ Windows Registry Editor Version 5.00
 
     [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
     "AutoAdminLogon"="0"
+
+    [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Keyboard Layout]
+    "IgnoreRemoteKeyboardLayout"=dword:00000001


### PR DESCRIPTION
Added the IgnoreRemoteKeyboardLayout Registry Key to prevent automatic changes to the keyboard layout.

As mentioned in [this article](https://poweradm.com/ignoreremotekeyboardlayout-windows-rdp/) the rdp server adds and activates the US keyboard-layout if the keyboard-layout of the RDP client does not match the RDP servers.
Since our client is on linux it is very likely that this is the case.
This changes makes the RDP-session ignore the clients keyboard-layout and keeps the one that is configured on the server (= the one set up during the setup of the windows VM).