### PR TITLE
Fix timezone issues in Docker VM

### DIFF
--- a/oem/RDPApps.reg
+++ b/oem/RDPApps.reg
@@ -8,3 +8,6 @@ Windows Registry Editor Version 5.00
 
     [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
     "AutoAdminLogon"="0"
+
+    [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation]
+    "RealTimeIsUniversal"=dword:00000001


### PR DESCRIPTION
This registry key fixed an issue with the VM's timezone changing itself after each reboot. Related issue: https://github.com/dockur/windows/issues/672
