### PR TITLE
use netcat instead of netcat-gnu

### DIFF
--- a/packages/winapps/default.nix
+++ b/packages/winapps/default.nix
@@ -6,7 +6,7 @@
   freerdp3,
   dialog,
   libnotify,
-  netcat-gnu,
+  netcat,
   iproute2,
   ...
 }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     freerdp3
     libnotify
     dialog
-    netcat-gnu
+    netcat
     iproute2
   ];
 


### PR DESCRIPTION
On my machine, `nc` from netcat-gnu does not work, which makes winapps not work in manual mode (winapps thinks port 3389 not open, but it is actually open).

use `nc` from netcat works.