### PR TITLE
Add the reMarkable desktop app

### DIFF
--- a/apps/remarkable-desktop/icon.svg
+++ b/apps/remarkable-desktop/icon.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Livello_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1881.25 1750"
+   enable-background="new 0 0 1881.25 1750"
+   xml:space="preserve"
+   sodipodi:docname="icon.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:ns="&amp;ns_sfw;"><defs
+   id="defs34" /><sodipodi:namedview
+   id="namedview32"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="0.58685714"
+   inkscape:cx="940.6037"
+   inkscape:cy="800.02434"
+   inkscape:window-width="2494"
+   inkscape:window-height="1371"
+   inkscape:window-x="66"
+   inkscape:window-y="32"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Livello_1" />
+<metadata
+   id="metadata2">
+    <ns:sfw>
+        <ns:slices />
+        <ns:sliceSourceBounds
+   bottomLeftOrigin="true"
+   height="1750"
+   width="1881.25"
+   x="-938.5"
+   y="-851" />
+    </ns:sfw>
+</metadata>
+
+
+
+
+
+
+
+
+<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="167.2057"
+   y1="1420.9117"
+   x2="795.2943"
+   y2="333.0883"
+   gradientTransform="matrix(1 0 0 -1 0 1752)">
+    <stop
+   offset="0"
+   style="stop-color:#2368C4"
+   id="stop20" />
+    <stop
+   offset="0.5"
+   style="stop-color:#1A5DBE"
+   id="stop22" />
+    <stop
+   offset="1"
+   style="stop-color:#1146AC"
+   id="stop24" />
+</linearGradient>
+
+
+<rect
+   style="fill:#fff6d5"
+   id="rect399"
+   width="1881.25"
+   height="1750"
+   x="0"
+   y="0"
+   ry="134.62839" /><text
+   xml:space="preserve"
+   style="font-size:1066.67px;fill:#000000;-inkscape-font-specification:serif;font-family:serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
+   x="204.01395"
+   y="1266.3248"
+   id="text295"><tspan
+     sodipodi:role="line"
+     id="tspan293"
+     x="204.01395"
+     y="1266.3248">rM</tspan></text></svg>

--- a/apps/remarkable-desktop/info
+++ b/apps/remarkable-desktop/info
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Marcus Bannerman
+# All rights reserved.
+#
+# SPDX-License-Identifier: Proprietary
+
+# GNOME shortcut name
+NAME="reMarkable"
+
+# Used for descriptions and window class
+FULL_NAME="reMarkable Desktop App"
+
+# The executable inside windows
+WIN_EXECUTABLE="C:\Program Files\reMarkable\reMarkable.exe"
+
+# GNOME categories
+CATEGORIES="WinApps;Office"
+
+# GNOME mimetypes
+MIME_TYPES=""
+
+# System Icon
+ICON="reMarkable"


### PR DESCRIPTION
I've added support for the reMarkable's desktop app
https://remarkable.com/
This is not "autodetected" by setup.sh in the unsupported application part, so adding it as a "supported" app enables it to be used.
I drew the icon for the app myself, its inspired by the normal icon design but I deliberately used a standard color and serif font to avoid being a direct replica, which is hard given how trivial the original design is.

Please let me know if you need anything else, and thank you for such an awesome tool!