### PR TITLE
fix(packages/winapps-launcher): Rename `WinAppsLauncher` related to `WinApps-Launcher`

### DIFF
--- a/packages/winapps-launcher/WinApps-Launcher.patch
+++ b/packages/winapps-launcher/WinApps-Launcher.patch
@@ -1,5 +1,5 @@
---- a/WinAppsLauncher.sh
-+++ b/WinAppsLauncher.sh
+--- a/WinApps-Launcher.sh
++++ b/WinApps-Launcher.sh
 @@ -19,7 +19,7 @@ declare -rx EC_WIN_NOT_SPEC=6
  declare -rx EC_NO_WIN_FOUND=7
 

--- a/packages/winapps-launcher/default.nix
+++ b/packages/winapps-launcher/default.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
     (callPackage ../winapps { })
   ];
 
-  patches = [ ./WinAppsLauncher.patch ];
+  patches = [ ./WinApps-Launcher.patch ];
 
   postPatch = ''
-    substituteAllInPlace WinAppsLauncher.sh
+    substituteAllInPlace WinApps-Launcher.sh
   '';
 
   installPhase = ''
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r ./Icons $out/Icons
 
-    install -m755 -D WinAppsLauncher.sh $out/bin/winapps-launcher
+    install -m755 -D WinApps-Launcher.sh $out/bin/winapps-launcher
     install -Dm444 -T Icons/AppIcon.svg $out/share/pixmaps/winapps.svg
 
     wrapProgram $out/bin/winapps-launcher \


### PR DESCRIPTION
The upstream has renamed the file `WinAppsLauncher.sh` to `WinApps-Launcher.sh`.