### PR TITLE
doc: install libnotify-tools instead of libnotify on OpenSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Install the required dependencies.
       ```
   - OpenSUSE:
       ```bash
-      sudo zypper install -y curl dialog freerdp git iproute2 libnotify netcat-openbsd
+      sudo zypper install -y curl dialog freerdp git iproute2 libnotify-tools netcat-openbsd
       ```
   - Gentoo Linux:
       ```bash


### PR DESCRIPTION
Closes #414