### PR TITLE
Fix error 14 during setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1046,7 +1046,7 @@ function waCheckRDPAccess() {
         +home-drive \
         -wallpaper \
         +dynamic-resolution \
-        /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C type NUL > "$TEST_PATH_WIN" && tsdiscon" \
+        /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C type NUL > $TEST_PATH_WIN && tsdiscon" \
         /v:"$RDP_IP" &>"$FREERDP_LOG" &
 
     # Store the FreeRDP process ID.


### PR DESCRIPTION
Should fix #244 and potentially #391

Had the same issue as #244 and discovered some quotes in line 1049 of setup.sh were the culprit, removed them and it is confirmed to work like a charm on both my own machine and a friend's separate Arch install