### PR TITLE
fix: Change default to Win11 Pro

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,11 +22,12 @@ services:
       USERNAME: "MyWindowsUser" # Edit here to set a custom Windows username. The default is 'MyWindowsUser'.
       PASSWORD: "MyWindowsPassword" # Edit here to set a password for the Windows user. The default is 'MyWindowsPassword'.
       HOME: "${HOME}" # Set path to Linux user home folder.
-    privileged: true # Grant the Windows VM extended privileges.
     ports:
       - 8006:8006 # Map '8006' on Linux host to '8006' on Windows VM --> For VNC Web Interface @ http://127.0.0.1:8006.
       - 3389:3389/tcp # Map '3389' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP).
       - 3389:3389/udp # Map '3389' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP).
+    cap_add:
+      - NET_ADMIN  # Add network permission
     stop_grace_period: 120s # Wait 120 seconds before sending SIGTERM when attempting to shut down the Windows VM.
     restart: on-failure # Restart the Windows VM if the exit code indicates an error.
     volumes:
@@ -37,5 +38,6 @@ services:
       #- /path/to/windows/install/media.iso:/custom.iso # Uncomment to use a custom Windows ISO. If specified, 'VERSION' (e.g. 'tiny11') will be ignored.
     devices:
       - /dev/kvm # Enable KVM.
+      - /dev/net/tun # Enable tuntap
       #- /dev/sdX:/disk1 # Uncomment to mount a disk directly within the Windows VM (Note: 'disk1' will be mounted as the main drive. THIS DISK WILL BE FORMATTED BY DOCKER).
       #- /dev/sdY:/disk2 # Uncomment to mount a disk directly within the Windows VM (Note: 'disk2' and higher will be mounted as secondary drives. THIS DISK WILL NOT BE FORMATTED).


### PR DESCRIPTION
The compose file currently defaults to Tiny11, but this is not ideal for two reasons:

  - There is only one download mirror for Tiny11 (archive.org, which is extremely slow).
  - It crashes on some systems, see: https://github.com/dockur/windows/issues/1177

The Win11 Pro preset has multiple high-speed download mirrors, and it doesnt crash on systems where Tiny11 does.

If people insist on using Tiny11, they can still do so by modifying `VERSION` or providing a .iso file, at their own risk.