### PR TITLE
docs: Correct readme

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -56,6 +56,7 @@ docker compose --file ~/.config/winapps/compose.yaml down
 rm ~/.config/freerdp/server/127.0.0.1_3389.pem
 
 # Re-create the container with the updated configuration.
+# Add the -d flag at the end to run the container in the background.
 docker compose --file ~/.config/winapps/compose.yaml up
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ Although WinApps supports using `QEMU+KVM+libvirt` as a backend for running Wind
 > [!IMPORTANT]
 > WinApps does __NOT__ officially support versions of Windows prior to Windows 10. Despite this, it may be possible to achieve a successful installation with some additional experimentation. If you find a way to achieve this, please share your solution through a pull request for the benefit of other users.
 > Possible setup instructions for Windows 10:
-> - 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will __NOT__ suffice. It is recommended to download the ISO from a reputed source, as the built in downloader from dockur (default set to `tiny11`) will take longer than it would to download from a browser/torrent.
+> - 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will __NOT__ suffice. 
 > - It is recommended to edit the initial `compose.yaml` file to keep your required username and password from the beginning.
 > - It is recommended to not use `sudo` to force commands to run. Add your user to the relevant permissions group wherever possible.
 
@@ -27,9 +27,6 @@ Prior to installing Windows, you can modify the RAM and number of CPU cores avai
 
 It is also possible to specify the version of Windows you wish to install within `compose.yaml` by modifying `VERSION`.
 
-> [!NOTE]
-> WinApps uses a stripped-down Windows installation by default. Although this is recommended, you can request a stock Windows installation by changing `VERSION` to one of the versions listed in the README of the [original GitHub repository](https://github.com/dockur/windows).
-
 Please refer to the [original GitHub repository](https://github.com/dockur/windows) for more information on additional configuration options.
 
 > [!NOTE]
@@ -46,24 +43,6 @@ docker compose --file ./compose.yaml up
 ```
 
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
-
-After installing Windows, comment out the following lines in the `compose.yaml` file by prepending a '#':
-- `- ./oem:/oem`
-- `- /path/to/windows/install/media.iso:/custom.iso` (if relevant)
-
-Then, copy this modified `compose.yaml` file to `~/.config/winapps/compose.yaml`.
-
-```bash
-cp ./compose.yaml ~/.config/winapps/compose.yaml
-```
-
-Finally, ensure the new configuration is applied by running the following:
-
-```bash
-docker compose --file ./compose.yaml down
-docker compose --file ~/.config/winapps/compose.yaml up
-```
-
 
 ### Changing `compose.yaml`
 Changes to `compose.yaml` require the Windows virtual machine to be removed and re-created. This should __NOT__ affect your data.
@@ -109,23 +88,6 @@ podman-compose --file ./compose.yaml up
 ```
 
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
-
-After installing Windows, comment out the following lines in the `compose.yaml` file by prepending a '#':
-- `- ./oem:/oem`
-- `- /path/to/windows/install/media.iso:/custom.iso` (if relevant)
-
-Then, copy this modified `compose.yaml` file to `~/.config/winapps/compose.yaml`.
-
-```bash
-cp ./compose.yaml ~/.config/winapps/compose.yaml
-```
-
-Finally, ensure the new configuration is applied by running the following:
-
-```bash
-podman-compose --file ./compose.yaml down
-podman-compose --file ~/.config/winapps/compose.yaml up
-```
 
 ### Changing `compose.yaml`
 Changes to `compose.yaml` require the Windows virtual machine to be removed and re-created. This should __NOT__ affect your data.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ Although WinApps supports using `QEMU+KVM+libvirt` as a backend for running Wind
 > [!IMPORTANT]
 > WinApps does __NOT__ officially support versions of Windows prior to Windows 10. Despite this, it may be possible to achieve a successful installation with some additional experimentation. If you find a way to achieve this, please share your solution through a pull request for the benefit of other users.
 > Possible setup instructions for Windows 10:
-> - 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will __NOT__ suffice. 
+> - 'Professional', 'Enterprise' or 'Server' editions of Windows are required to run RDP applications. Windows 'Home' will __NOT__ suffice.
 > - It is recommended to edit the initial `compose.yaml` file to keep your required username and password from the beginning.
 > - It is recommended to not use `sudo` to force commands to run. Add your user to the relevant permissions group wherever possible.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -45,17 +45,17 @@ docker compose --file ./compose.yaml up
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
 
 ### Changing `compose.yaml`
-Changes to `compose.yaml` require the Windows virtual machine to be removed and re-created. This should __NOT__ affect your data.
+Changes to `compose.yaml` require the container to be removed and re-created. This should __NOT__ affect your data.
 
 ```bash
-# Stop and remove the existing Windows virtual machine.
+# Stop and remove the existing container.
 docker compose --file ~/.config/winapps/compose.yaml down
 
 # Remove the existing FreeRDP certificate (if required).
 # Note: A new certificate will be created when connecting via RDP for the first time.
 rm ~/.config/freerdp/server/127.0.0.1_3389.pem
 
-# Re-create the virtual machine with the updated configuration.
+# Re-create the container with the updated configuration.
 docker compose --file ~/.config/winapps/compose.yaml up
 ```
 
@@ -90,17 +90,17 @@ podman-compose --file ./compose.yaml up
 You can then access the Windows virtual machine via a VNC connection to complete the Windows setup by navigating to http://127.0.0.1:8006 in your web browser.
 
 ### Changing `compose.yaml`
-Changes to `compose.yaml` require the Windows virtual machine to be removed and re-created. This should __NOT__ affect your data.
+Changes to `compose.yaml` require the container to be removed and re-created. This should __NOT__ affect your data.
 
 ```bash
-# Stop and remove the existing Windows virtual machine.
+# Stop and remove the existing container.
 podman-compose --file ~/.config/winapps/compose.yaml down
 
 # Remove the existing FreeRDP certificate (if required).
 # Note: A new certificate will be created when connecting via RDP for the first time.
 rm ~/.config/freerdp/server/127.0.0.1_3389.pem
 
-# Re-create the virtual machine with the updated configuration.
+# Re-create the container with the updated configuration.
 podman-compose --file ~/.config/winapps/compose.yaml up
 ```
 


### PR DESCRIPTION
In the Readme for the Docker method it says:

```
After installing Windows, comment out the following lines in the `compose.yaml` file by prepending .....
```

and then it explains how to bind the `OEM` folder or a custom .iso, but I really don't understand why that was done.

Because after Windows installation has finished, setting the `OEM` folder has zero effect anymore, it only is used DURING installation. Same goes for the custom .iso.

There must be a reason why the creator of that document suggested to do it in a two-step process, where you don't add the `OEM` folder from the beginning, but I don't know the rationale behind it.

Maybe @KernelGhost can shed some light on why he took this approach?