### PR TITLE
Share mounted media via /run/media

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,13 @@ WAFLAVOR="docker"
 # - '140'
 # - '180'
 RDP_SCALE="100"
-
+# [MOUNTING REMOVEABLE PATHS FOR FILES]
+# NOTES:
+# udisks which you most probalbly have installed ,use /run/media by default.
+# This will improve the experience while using DEs.
+# However,FHS suggests using /media.Please check your system.
+# If you prefer to mount manually,you can change it to /mnt.
+REMOVABLE_MEDIA = "/run/media"
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]
 # NOTES:
 # - You can try adding /network:lan to these flags in order to increase performance, however, some users have faced issues with this.

--- a/README.md
+++ b/README.md
@@ -383,13 +383,15 @@ WAFLAVOR="docker"
 # - '140'
 # - '180'
 RDP_SCALE="100"
-# [MOUNTING REMOVEABLE PATHS FOR FILES]
-# NOTES:
-# udisks which you most probalbly have installed ,use /run/media by default.
-# This will improve the experience while using DEs.
-# However,FHS suggests using /media.Please check your system.
-# If you prefer to mount manually,you can change it to /mnt.
-REMOVABLE_MEDIA = "/run/media"
+
+# [MOUNTING REMOVABLE PATHS FOR FILES]  
+# NOTES:  
+# - By default, `udisks` (which you most likely have installed) uses `/run/media/` for mounting removable devices.  
+# - This improves compatibility with most desktop environments (DEs).  
+# - Note: The Filesystem Hierarchy Standard (FHS) recommends `/media` instead. Verify your system's configuration.  
+# - To manually mount devices, you may optionally use `/mnt`.  
+REMOVABLE_MEDIA="/run/media"
+
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]
 # NOTES:
 # - You can try adding /network:lan to these flags in order to increase performance, however, some users have faced issues with this.

--- a/README.md
+++ b/README.md
@@ -386,10 +386,11 @@ RDP_SCALE="100"
 
 # [MOUNTING REMOVABLE PATHS FOR FILES]
 # NOTES:
-# - By default, `udisks` (which you most likely have installed) uses `/run/media/` for mounting removable devices.
-# - This improves compatibility with most desktop environments (DEs).
-# - Note: The Filesystem Hierarchy Standard (FHS) recommends `/media` instead. Verify your system's configuration.
-# - To manually mount devices, you may optionally use `/mnt`.
+# - By default, `udisks` (which you most likely have installed) uses /run/media for mounting removable devices.
+#   This improves compatibility with most desktop environments (DEs).
+# ATTENTION: The Filesystem Hierarchy Standard (FHS) recommends /media instead. Verify your system's configuration.
+# - To manually mount devices, you may optionally use /mnt.
+# REFERRENCE: https://wiki.archlinux.org/title/Udisks#Mount_to_/media
 REMOVABLE_MEDIA="/run/media"
 
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]

--- a/README.md
+++ b/README.md
@@ -384,12 +384,12 @@ WAFLAVOR="docker"
 # - '180'
 RDP_SCALE="100"
 
-# [MOUNTING REMOVABLE PATHS FOR FILES]  
-# NOTES:  
-# - By default, `udisks` (which you most likely have installed) uses `/run/media/` for mounting removable devices.  
-# - This improves compatibility with most desktop environments (DEs).  
-# - Note: The Filesystem Hierarchy Standard (FHS) recommends `/media` instead. Verify your system's configuration.  
-# - To manually mount devices, you may optionally use `/mnt`.  
+# [MOUNTING REMOVABLE PATHS FOR FILES]
+# NOTES:
+# - By default, `udisks` (which you most likely have installed) uses `/run/media/` for mounting removable devices.
+# - This improves compatibility with most desktop environments (DEs).
+# - Note: The Filesystem Hierarchy Standard (FHS) recommends `/media` instead. Verify your system's configuration.
+# - To manually mount devices, you may optionally use `/mnt`.
 REMOVABLE_MEDIA="/run/media"
 
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]

--- a/bin/winapps
+++ b/bin/winapps
@@ -581,7 +581,8 @@ function waRunCommand() {
         else
             # Convert path from UNIX to Windows style.
             FILE_PATH=$(echo "$2" | sed \
-                -e 's|'"${HOME}"'|\\\\tsclient\\home|' \
+                -e 's|^'"${HOME}"'|\\\\tsclient\\home|' \
+                -e 's|^/run/media|\\\\tsclient\\media|' \
                 -e 's|/|\\|g')
             dprint "UNIX_FILE_PATH: ${2}"
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
@@ -595,6 +596,7 @@ function waRunCommand() {
                 +auto-reconnect \
                 +home-drive \
                 +clipboard \
+                /drive:media,/run/media \
                 -wallpaper \
                 "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \

--- a/bin/winapps
+++ b/bin/winapps
@@ -45,6 +45,7 @@ RDP_IP=""
 WAFLAVOR="docker"
 RDP_FLAGS=""
 FREERDP_COMMAND=""
+REMOVABLE_MEDIA=""
 RDP_SCALE=100
 AUTOPAUSE="off"
 AUTOPAUSE_TIME="300"
@@ -156,7 +157,16 @@ Please run:
 function dprint() {
     [ "$DEBUG" = "true" ] && echo "[$(date)-$RUNID] $1" >>"$LOG_PATH"
 }
-
+# Name: 'waFixRemovableMedia'
+# Role: If user left REMOVABLE_MEDIA config null,fallback to /run/media for udisks defaults ,warning.
+function waFixRemovableMedia() {
+    if [ -z "$REMOVABLE_MEDIA" ]; then
+        REMOVABLE_MEDIA="/run/media"  # Default for udisks
+        dprint "NOTICE: Using default REMOVABLE_MEDIA: $REMOVABLE_MEDIA"
+        notify-send --expire-time=3000 --icon="drive-removable-media" \
+            "WinApps Notice" "Using default removable media path: $REMOVABLE_MEDIA"
+    fi
+}
 # Name: 'waFixScale'
 # Role: Since FreeRDP only supports '/scale' values of 100, 140 or 180, find the closest supported argument to the user's configuration.
 function waFixScale() {
@@ -207,7 +217,8 @@ function waLoadConfig() {
 
     # Update $RDP_SCALE.
     waFixScale
-
+    # Update when $REMOVABLE_MEDIA is null
+    waFixRemovableMedia
     # Update $AUTOPAUSE_TIME.
     # RemoteApp RDP sessions take, at minimum, 20 seconds to be terminated by the Windows server.
     # Hence, subtract 20 from the timeout specified by the user, as a 'built in' timeout of 20 seconds will occur.
@@ -582,7 +593,7 @@ function waRunCommand() {
             # Convert path from UNIX to Windows style.
             FILE_PATH=$(echo "$2" | sed \
                 -e 's|^'"${HOME}"'|\\\\tsclient\\home|' \
-                -e 's|^/run/media|\\\\tsclient\\media|' \
+                -e 's|^\('"${REMOVABLE_MEDIA//|/\\|}"'\)/[^/]*|\\\\tsclient\\media|' 、
                 -e 's|/|\\|g')
             dprint "UNIX_FILE_PATH: ${2}"
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
@@ -596,7 +607,7 @@ function waRunCommand() {
                 +auto-reconnect \
                 +home-drive \
                 +clipboard \
-                /drive:media,/run/media \
+                /drive:media,"$REMOVABLE_MEDIA" \
                 -wallpaper \
                 "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \

--- a/bin/winapps
+++ b/bin/winapps
@@ -593,7 +593,7 @@ function waRunCommand() {
             # Convert path from UNIX to Windows style.
             FILE_PATH=$(echo "$2" | sed \
                 -e 's|^'"${HOME}"'|\\\\tsclient\\home|' \
-                -e 's|^\('"${REMOVABLE_MEDIA//|/\\|}"'\)/[^/]*|\\\\tsclient\\media|' 、
+                -e 's|^\('"${REMOVABLE_MEDIA//|/\\|}"'\)/[^/]*|\\\\tsclient\\media|' \
                 -e 's|/|\\|g')
             dprint "UNIX_FILE_PATH: ${2}"
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"


### PR DESCRIPTION
Little fix for Dolphin user could directly open mounted files on portable devices like USB drive.
edit:
It is the default behavior fot udisks: [https://wiki.archlinux.org/title/Udisks#Mount_to_/media](archwiki).
But the FHS suggest [https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s11.html](url) using `/media`.
This version is released in 2015,10 years ago, so udisks doesn't follow it seems reasonable.