### PR TITLE
Document how to make rootless podman work

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -41,3 +41,5 @@ services:
       - /dev/net/tun # Enable tuntap
       #- /dev/sdX:/disk1 # Uncomment to mount a disk directly within the Windows VM (Note: 'disk1' will be mounted as the main drive. THIS DISK WILL BE FORMATTED BY DOCKER).
       #- /dev/sdY:/disk2 # Uncomment to mount a disk directly within the Windows VM (Note: 'disk2' and higher will be mounted as secondary drives. THIS DISK WILL NOT BE FORMATTED).
+    #group_add:      # uncomment this line and the next one for using rootless podman containers
+    #  - keep-groups # to make /dev/kvm work with podman. needs "crun" installed, "runc" will not work! Add your user to the 'kvm' group or another that can access /dev/kvm.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -98,6 +98,12 @@ docker compose --file ~/.config/winapps/compose.yaml kill # Force shut down the 
 ### Setup `Podman` Container
 Please follow the [`docker` instructions](#setup-docker-container).
 
+> [!NOTE]
+> #### Rootless `podman` containers
+> If you are invoking podman as a user, your container will be "rootless". This can be desirable as a security feature. However, you may encounter an error about missing permissions to /dev/kvm as a consequence.
+>
+> For rootless podman to work, you need to add your user to the `kvm` group (depending on your distribution) to be able to access `/dev/kvm`. Make sure that you are using `crun` as your container runtime, not `runc`. Usually this is done by stopping all containers and (de-)installing the corresponding packages. Then either invoke podman-compose as `podman-compose --file ./compose.yaml --podman-create-args '--group-add keep-groups' up`. Or edit `compose.yaml` and uncomment the `group_add:` section at the end.
+
 > [!IMPORTANT]
 > Ensure `WAFLAVOR` is set to `"podman"` in `~/.config/winapps/winapps.conf`.
 


### PR DESCRIPTION
The documentation describes how to use podman like docker. But when using podman as a user to take advantage of its 'rootless' feature, a permission error accessing /dev/kvm will often be encountered.

This PR adds documentation about how to fix that problem.

See also https://github.com/containers/podman/blob/main/troubleshooting.md#20-passed-in-device-cant-be-accessed-in-rootless-container and https://github.com/containers/podman/issues/10166

v2: Fixed whitespace damage in previous cancelled PR https://github.com/winapps-org/winapps/pull/495 .