### PR TITLE
Add protocol handler for Microsoft Office links (e.g. ms-office://)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ WinApps works by:
 - The GNU/Linux `/home` directory is accessible within Windows via the `\\tsclient\home` mount.
 - Integration with `Nautilus`, allowing you to right-click files to open them with specific Windows applications based on the file MIME type.
 - The [official taskbar widget](https://github.com/winapps-org/WinApps-Launcher) enables seamless administration of the Windows subsystem and offers an easy way to launch Windows applications.
+- Microsoft Office links (e.g. ms-word://) from the host system are automatically opened in the Windows subsystem. (Note: You may need to use a [User-Agent-switcher] (https://github.com/ray-lothian/UserAgent-Switcher/) and set the User-Agent to Windows, as Office's web interface typically hides the "Open in Desktop App" option for Linux users.)
 
 ## Supported Applications
 **WinApps supports <u>*ALL*</u> Windows applications.**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ WinApps works by:
 - The GNU/Linux `/home` directory is accessible within Windows via the `\\tsclient\home` mount.
 - Integration with `Nautilus`, allowing you to right-click files to open them with specific Windows applications based on the file MIME type.
 - The [official taskbar widget](https://github.com/winapps-org/WinApps-Launcher) enables seamless administration of the Windows subsystem and offers an easy way to launch Windows applications.
-- Microsoft Office links (e.g. ms-word://) from the host system are automatically opened in the Windows subsystem. (Note: You may need to use a [User-Agent-switcher] (https://github.com/ray-lothian/UserAgent-Switcher/) and set the User-Agent to Windows, as Office's web interface typically hides the "Open in Desktop App" option for Linux users.)
+- Microsoft Office links (e.g. ms-word://) from the host system are automatically opened in the Windows subsystem. (Note: You may need to use an [User Agent switcher](https://github.com/ray-lothian/UserAgent-Switcher/) Browser Extension and set the User-Agent to Windows, as as the Office webapps typically hide the "Open in Desktop App" option for Linux users.)
 
 ## Supported Applications
 **WinApps supports <u>*ALL*</u> Windows applications.**

--- a/apps/ms-office-protocol-handler.desktop
+++ b/apps/ms-office-protocol-handler.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Microsoft Office Protocol Handler
 Comment=Handle Microsoft Office URI schemes via WinApps
-Exec=/usr/local/bin/winapps manual %u
+Exec=winapps manual %u
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/ms-word;x-scheme-handler/ms-excel;x-scheme-handler/ms-powerpoint;x-scheme-handler/ms-outlook;x-scheme-handler/ms-access;x-scheme-handler/ms-visio;x-scheme-handler/ms-project;x-scheme-handler/ms-teams;x-scheme-handler/ms-whiteboard;x-scheme-handler/ms-officeapp;

--- a/apps/ms-office-protocol-handler.desktop
+++ b/apps/ms-office-protocol-handler.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Microsoft Office Protocol Handler
+Comment=Handle Microsoft Office URI schemes via WinApps
+Exec=/usr/local/bin/winapps manual %u
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/ms-word;x-scheme-handler/ms-excel;x-scheme-handler/ms-powerpoint;x-scheme-handler/ms-outlook;x-scheme-handler/ms-access;x-scheme-handler/ms-visio;x-scheme-handler/ms-project;x-scheme-handler/ms-teams;x-scheme-handler/ms-whiteboard;x-scheme-handler/ms-officeapp;
+NoDisplay=true
+Categories=Office;Utility;

--- a/setup.sh
+++ b/setup.sh
@@ -156,7 +156,7 @@ function waGetSourceCode() {
     fi
 
     if [[ ! -d "$SOURCE_PATH" ]]; then
-        $SUDO git clone --recurse-submodules --remote-submodules https://github.com/fluffy-git/winapps.git "$SOURCE_PATH"
+        $SUDO git clone --recurse-submodules --remote-submodules https://github.com/winapps-org/winapps.git "$SOURCE_PATH"
     else
         echo -e "${INFO_TEXT}WinApps installation already present at ${CLEAR_TEXT}${COMMAND_TEXT}${SOURCE_PATH}${CLEAR_TEXT}${INFO_TEXT}. Updating...${CLEAR_TEXT}"
         $SUDO git -C "$SOURCE_PATH" pull --no-rebase
@@ -196,7 +196,7 @@ function waGetInquirer() {
         INQUIRER="/tmp/waInquirer.sh"
         rm -f "$INQUIRER"
 
-        curl -o "$INQUIRER" "https://raw.githubusercontent.com/fluffy-git/winapps/main/install/inquirer.sh"
+        curl -o "$INQUIRER" "https://raw.githubusercontent.com/winapps-org/winapps/main/install/inquirer.sh"
     fi
 
     # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.

--- a/setup.sh
+++ b/setup.sh
@@ -156,7 +156,7 @@ function waGetSourceCode() {
     fi
 
     if [[ ! -d "$SOURCE_PATH" ]]; then
-        $SUDO git clone --recurse-submodules --remote-submodules https://github.com/winapps-org/winapps.git "$SOURCE_PATH"
+        $SUDO git clone --recurse-submodules --remote-submodules https://github.com/fluffy-git/winapps.git "$SOURCE_PATH"
     else
         echo -e "${INFO_TEXT}WinApps installation already present at ${CLEAR_TEXT}${COMMAND_TEXT}${SOURCE_PATH}${CLEAR_TEXT}${INFO_TEXT}. Updating...${CLEAR_TEXT}"
         $SUDO git -C "$SOURCE_PATH" pull --no-rebase
@@ -196,7 +196,7 @@ function waGetInquirer() {
         INQUIRER="/tmp/waInquirer.sh"
         rm -f "$INQUIRER"
 
-        curl -o "$INQUIRER" "https://raw.githubusercontent.com/winapps-org/winapps/main/install/inquirer.sh"
+        curl -o "$INQUIRER" "https://raw.githubusercontent.com/fluffy-git/winapps/main/install/inquirer.sh"
     fi
 
     # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.
@@ -1136,6 +1136,10 @@ function waFindInstalled() {
     for APPLICATION in ./apps/*; do
         # Extract the name of the application from the absolute path of the folder.
         APPLICATION="$(basename "$APPLICATION")"
+
+        if [[ "$APPLICATION" == "ms-office-protocol-handler.desktop" ]]; then
+            continue
+        fi
 
         # Source 'Info' File Containing:
         # - The Application Name          (FULL_NAME)

--- a/setup.sh
+++ b/setup.sh
@@ -1320,9 +1320,9 @@ MimeType=${MIME_TYPES}"
 function waConfigureOfficiallySupported() {
     # Declare variables.
     local OSA_LIST=() # Stores a list of all officially supported applications installed on Windows.
+    local OFFICE_APPS=("access" "access-o365" "access-o365-x86" "access-x86" "adobe-cc" "acrobat9" "acrobat-x-pro" "aftereffects-cc" "audition-cc" "bridge-cc" "bridge-cc-x86" "bridge-cs6" "bridge-cs6-x86" "cmd" "dymo-connect" "excel" "excel-o365" "excel-o365-x86" "excel-x86" "excel-x86-2010" "explorer" "iexplorer" "illustrator-cc" "lightroom-cc" "linqpad8" "mirc" "mspaint" "onenote" "onenote-o365" "onenote-o365-x86" "onenote-x86" "outlook" "outlook-o365" "outlook-o365-x86" "powerpoint" "powerpoint-o365" "powerpoint-o365-x86" "powerpoint-x86" "publisher" "publisher-o365" "publisher-o365-x86" "publisher-x86" "project" "project-x86" "remarkable-desktop" "ssms20" "visual-studio-comm" "visual-studio-ent" "visual-studio-pro" "visio" "visio-x86" "word" "word-o365" "word-o365-x86" "word-x86" "word-x86-2010")
 
     # Read the list of officially supported applications that are installed on Windows into an array, returning an empty array if no such files exist.
-    # This will remove leading and trailing whitespace characters as well as ignore empty lines.
     readarray -t OSA_LIST < <(grep -v '^[[:space:]]*$' "$INST_FILE_PATH" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' 2>/dev/null || true)
 
     # Create application entries for each officially supported application.
@@ -1335,6 +1335,19 @@ function waConfigureOfficiallySupported() {
 
         # Configure the application.
         waConfigureApp "$OSA" svg
+
+        # Check if the application is an Office app and copy the protocol handler.
+        if [[ " ${OFFICE_APPS[*]} " == *" $OSA "* ]]; then
+            # Determine the target directory based on whether the installation is for the system or user.
+            if [[ "$OPT_SYSTEM" -eq 1 ]]; then
+                TARGET_DIR="$SYS_APP_PATH"
+            else
+                TARGET_DIR="$USER_APP_PATH"
+            fi
+
+            # Copy the protocol handler to the appropriate directory.
+            $SUDO cp "./apps/ms-office-protocol-handler.desktop" "$TARGET_DIR/ms-office-protocol-handler.desktop"
+        fi
 
         # Print feedback.
         echo -e "${DONE_TEXT}Done!${CLEAR_TEXT}"
@@ -1667,9 +1680,20 @@ function waEnsureOnPath() {
 # Name: 'waUninstall'
 # Role: Uninstalls WinApps.
 function waUninstall() {
+    
     # Print feedback.
     [ "$OPT_SYSTEM" -eq 1 ] && echo -e "${BOLD_TEXT}REMOVING SYSTEM INSTALLATION.${CLEAR_TEXT}"
     [ "$OPT_USER" -eq 1 ] && echo -e "${BOLD_TEXT}REMOVING USER INSTALLATION.${CLEAR_TEXT}"
+
+    # Determine the target directory for the protocol handler based on the installation type.
+    if [[ "$OPT_SYSTEM" -eq 1 ]]; then
+        TARGET_DIR="$SYS_APP_PATH"
+    else
+        TARGET_DIR="$USER_APP_PATH"
+    fi
+
+    # Remove the 'ms-office-protocol-handler.desktop' file if it exists.
+    $SUDO rm -f "$TARGET_DIR/ms-office-protocol-handler.desktop"
 
     # Declare variables.
     local WINAPPS_DESKTOP_FILES=()    # Stores a list of '.desktop' file paths.

--- a/setup.sh
+++ b/setup.sh
@@ -1684,7 +1684,7 @@ function waEnsureOnPath() {
 # Name: 'waUninstall'
 # Role: Uninstalls WinApps.
 function waUninstall() {
-    
+
     # Print feedback.
     [ "$OPT_SYSTEM" -eq 1 ] && echo -e "${BOLD_TEXT}REMOVING SYSTEM INSTALLATION.${CLEAR_TEXT}"
     [ "$OPT_USER" -eq 1 ] && echo -e "${BOLD_TEXT}REMOVING USER INSTALLATION.${CLEAR_TEXT}"


### PR DESCRIPTION
Adds ms-office-protocol-handler.desktop (+installing and uninstalling logic) to route Office web links (ms-word://, ms-excel://, ...) through to the Windows VM. Just a small convenience feature I've added, thought I'd share it. 

Needs an user agent switcher, see updated readme