### PR TITLE
Allow libvirt VM name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,13 @@ RDP_DOMAIN=""
 # - 'libvirt': '' (BLANK)
 RDP_IP="127.0.0.1"
 
+# [VM NAME]
+# NOTES:
+# - Only applicable when using 'libvirt'
+# - The libvirt VM name must match so that WinApps can determine VM IP, start the VM, etc.
+# DEFAULT VALUE: 'RDPWindows'
+VM_NAME="RDPWindows"
+
 # [WINAPPS BACKEND]
 # DEFAULT VALUE: 'docker'
 # VALID VALUES:

--- a/bin/winapps
+++ b/bin/winapps
@@ -124,7 +124,7 @@ Please run:
         ;;
     "$EC_NOT_EXIST")
         dprint "ERROR: WINDOWS NONEXISTENT. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows does not exist."
+        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows VM named '${VM_NAME}' does not exist."
         ;;
     "$EC_UNKNOWN")
         dprint "ERROR: UNKNOWN CONTAINER ERROR. EXITING."

--- a/bin/winapps
+++ b/bin/winapps
@@ -29,7 +29,6 @@ readonly COMPOSE_PATH="${HOME}/.config/winapps/compose.yaml"
 readonly SCRIPT_DIR_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # OTHER
-readonly VM_NAME="RDPWindows" # FOR 'libvirt' ONLY
 readonly CONTAINER_NAME="WinApps" # FOR 'docker' AND 'podman' ONLY
 readonly RDP_PORT=3389
 readonly DOCKER_IP="127.0.0.1"
@@ -42,6 +41,7 @@ RDP_USER=""
 RDP_PASS=""
 RDP_DOMAIN=""
 RDP_IP=""
+VM_NAME="RDPWindows" # FOR 'libvirt' ONLY
 WAFLAVOR="docker"
 RDP_FLAGS=""
 FREERDP_COMMAND=""

--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -132,6 +132,9 @@ Together, these components form a powerful and flexible virtualization stack, wi
     <img src="./libvirt_images/07.png" width="500px"/>
 </p>
 
+> [!NOTE]
+> A name other than `RDPWindows` can be used if `VM_NAME` is set in `~/.config/winapps/winapps.conf`.
+
 9. After clicking `Finish`, select `Copy host CPU configuration` under 'CPUs', and then click `Apply`.
 
 > [!NOTE]

--- a/packages/winapps/setup.patch
+++ b/packages/winapps/setup.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.sh b/setup.sh
-index b7d930d6..18000c65 100755
+index 0debe4d..6aeea08 100755
 --- a/setup.sh
 +++ b/setup.sh
 @@ -39,8 +39,8 @@ readonly SYS_BIN_PATH="/usr/local/bin"                  # UNIX path to 'bin' dir
@@ -21,7 +21,7 @@ index b7d930d6..18000c65 100755
 +readonly INQUIRER_PATH="@out@/src/install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
  
  # REMOTE DESKTOP CONFIGURATION
- readonly VM_NAME="RDPWindows"  # Name of the Windows VM (FOR 'libvirt' ONLY).
+ readonly RDP_PORT=3389         # Port used for RDP on Windows.
 @@ -155,13 +155,6 @@ function waGetSourceCode() {
          echo -e "${WARNING_TEXT}[WARNING]${CLEAR_TEXT} You might want to remove your old installation on '${SCRIPT_DIR_PATH}'."
      fi

--- a/setup.sh
+++ b/setup.sh
@@ -73,7 +73,6 @@ readonly CONFIG_PATH="${HOME}/.config/winapps/winapps.conf" # UNIX path to the W
 readonly INQUIRER_PATH="./install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
 
 # REMOTE DESKTOP CONFIGURATION
-readonly VM_NAME="RDPWindows"  # Name of the Windows VM (FOR 'libvirt' ONLY).
 readonly RDP_PORT=3389         # Port used for RDP on Windows.
 readonly DOCKER_IP="127.0.0.1" # Localhost.
 
@@ -85,17 +84,18 @@ OPT_UNINSTALL=0 # Set to '1' if the user specifies '--uninstall'.
 OPT_AOSA=0      # Set to '1' if the user specifies '--setupAllOfficiallySupportedApps'.
 
 # WINAPPS CONFIGURATION FILE
-RDP_USER=""        # Imported variable.
-RDP_PASS=""        # Imported variable.
-RDP_DOMAIN=""      # Imported variable.
-RDP_IP=""          # Imported variable.
-WAFLAVOR="docker"  # Imported variable.
-RDP_SCALE=100      # Imported variable.
-RDP_FLAGS=""       # Imported variable.
-MULTIMON="false"   # Imported variable.
-DEBUG="true"       # Imported variable.
-FREERDP_COMMAND="" # Imported variable.
-MULTI_FLAG=""      # Set based on value of $MULTIMON.
+RDP_USER=""          # Imported variable.
+RDP_PASS=""          # Imported variable.
+RDP_DOMAIN=""        # Imported variable.
+RDP_IP=""            # Imported variable.
+VM_NAME="RDPWindows" # Name of the Windows VM (FOR 'libvirt' ONLY).
+WAFLAVOR="docker"    # Imported variable.
+RDP_SCALE=100        # Imported variable.
+RDP_FLAGS=""         # Imported variable.
+MULTIMON="false"     # Imported variable.
+DEBUG="true"         # Imported variable.
+FREERDP_COMMAND=""   # Imported variable.
+MULTI_FLAG=""        # Set based on value of $MULTIMON.
 
 # PERMISSIONS AND DIRECTORIES
 SUDO=""         # Set to "sudo" if the user specifies '--system', or "" if the user specifies '--user'.


### PR DESCRIPTION
Users may have a use case where they would like to change the libvirt VM name to one other than the default `RDPWindows`. For example, I may want to switch between using two different VMs for winapps, but two VMs cannot have the same name in libvirt. In the future, support could be added for multiple, simultaneous VMs. I've made the following changes:

- Removed the `readonly` attributed from `VM_NAME` for `winapps` and `winapps-setup`
- Updated documentation
- Made the error message for not finding the VM more descriptive