### PR TITLE
Remove more default RDP flags to simplify debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,18 +403,9 @@ REMOVABLE_MEDIA="/run/media"
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]
 # NOTES:
 # - You can try adding /network:lan to these flags in order to increase performance, however, some users have faced issues with this.
-# DEFAULT VALUE: '/cert:tofu /sound /microphone'
+# DEFAULT VALUE: '/cert:tofu /sound /microphone +home-drive'
 # VALID VALUES: See https://github.com/awakecoding/FreeRDP-Manuals/blob/master/User/FreeRDP-User-Manual.markdown
-RDP_FLAGS="/cert:tofu /sound /microphone"
-
-# [MULTIPLE MONITORS]
-# NOTES:
-# - If enabled, a FreeRDP bug *might* produce a black screen.
-# DEFAULT VALUE: 'false'
-# VALID VALUES:
-# - 'true'
-# - 'false'
-MULTIMON="false"
+RDP_FLAGS="/cert:tofu /sound /microphone +home-drive"
 
 # [DEBUG WINAPPS]
 # NOTES:
@@ -466,7 +457,7 @@ FREERDP_COMMAND=""
 - For domain users, you can uncomment and change `RDP_DOMAIN`.
 - On high-resolution (UHD) displays, you can set `RDP_SCALE` to the scale you would like to use (100, 140 or 180).
 - To add additional flags to the FreeRDP call (e.g. `/prevent-session-lock 120`), uncomment and use the `RDP_FLAGS` configuration option.
-- For multi-monitor setups, you can try enabling `MULTIMON`. A FreeRDP bug may result in a black screen however, in which case you should revert this change.
+- For multi-monitor setups, you can try adding `/multimon` to `RDP_FLAGS`. A FreeRDP bug may result in a black screen however, in which case you should revert this change.
 - If you enable `DEBUG`, a log will be created on each application start in `~/.local/share/winapps/winapps.log`.
 - If using a system on which the FreeRDP command is not `xfreerdp` or `xfreerdp3`, the correct command can be specified using `FREERDP_COMMAND`.
 

--- a/bin/winapps
+++ b/bin/winapps
@@ -49,9 +49,7 @@ REMOVABLE_MEDIA=""
 RDP_SCALE=100
 AUTOPAUSE="off"
 AUTOPAUSE_TIME="300"
-MULTIMON="false"
 DEBUG="true"
-MULTI_FLAG=""
 
 # OTHER
 FREERDP_PID=-1
@@ -211,9 +209,6 @@ function waLoadConfig() {
     else
         waThrowExit $EC_MISSING_CONFIG
     fi
-
-    # Update 'MULTI_FLAG' based on 'MULTIMON'.
-    MULTI_FLAG=$([[ $MULTIMON == "true" ]] && echo "/multimon" || echo "+span")
 
     # Update $RDP_SCALE.
     waFixScale
@@ -521,11 +516,7 @@ function waRunCommand() {
             /u:"$RDP_USER" \
             /p:"$RDP_PASS" \
             /scale:"$RDP_SCALE" \
-            +dynamic-resolution \
             +auto-reconnect \
-            +home-drive \
-            +clipboard \
-            -wallpaper \
             /wm-class:"Microsoft Windows" \
             /t:"Windows RDP Session [$RDP_IP]" \
             /v:"$RDP_IP" &>/dev/null &
@@ -540,12 +531,7 @@ function waRunCommand() {
             /u:"$RDP_USER" \
             /p:"$RDP_PASS" \
             /scale:"$RDP_SCALE" \
-            +dynamic-resolution \
             +auto-reconnect \
-            +home-drive \
-            +clipboard \
-            -wallpaper \
-            "$MULTI_FLAG" \
             /app:program:"$2" \
             /v:"$RDP_IP" &>/dev/null &
 
@@ -577,12 +563,7 @@ function waRunCommand() {
                 /u:"$RDP_USER" \
                 /p:"$RDP_PASS" \
                 /scale:"$RDP_SCALE" \
-                +dynamic-resolution \
                 +auto-reconnect \
-                +home-drive \
-                +clipboard \
-                -wallpaper \
-                "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:"$FULL_NAME" \
                 /v:"$RDP_IP" &>/dev/null &
@@ -603,13 +584,8 @@ function waRunCommand() {
                 /u:"$RDP_USER" \
                 /p:"$RDP_PASS" \
                 /scale:"$RDP_SCALE" \
-                +dynamic-resolution \
                 +auto-reconnect \
-                +home-drive \
-                +clipboard \
                 /drive:media,"$REMOVABLE_MEDIA" \
-                -wallpaper \
-                "$MULTI_FLAG" \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:$"FULL_NAME",cmd:\""$FILE_PATH"\" \
                 /v:"$RDP_IP" &>/dev/null &

--- a/bin/winapps
+++ b/bin/winapps
@@ -517,6 +517,7 @@ function waRunCommand() {
             /p:"$RDP_PASS" \
             /scale:"$RDP_SCALE" \
             +auto-reconnect \
+            +dynamic-resolution \
             /wm-class:"Microsoft Windows" \
             /t:"Windows RDP Session [$RDP_IP]" \
             /v:"$RDP_IP" &>/dev/null &

--- a/compose.yaml
+++ b/compose.yaml
@@ -44,6 +44,6 @@ services:
       # NOTE: 'disk1' will be mounted as the main drive. THIS DISK WILL BE FORMATTED BY DOCKER.
       # All following disks (disk2, ...) WILL NOT BE FORMATTED.
       # - /dev/disk/by-id/<id>:/disk1
-      # - dev/disk/by-id/<id>:/disk2 
+      # - dev/disk/by-id/<id>:/disk2
     # group_add:      # uncomment this line and the next one for using rootless podman containers
     #   - keep-groups # to make /dev/kvm work with podman. needs "crun" installed, "runc" will not work! Add your user to the 'kvm' group or another that can access /dev/kvm.

--- a/setup.sh
+++ b/setup.sh
@@ -92,10 +92,8 @@ VM_NAME="RDPWindows" # Name of the Windows VM (FOR 'libvirt' ONLY).
 WAFLAVOR="docker"    # Imported variable.
 RDP_SCALE=100        # Imported variable.
 RDP_FLAGS=""         # Imported variable.
-MULTIMON="false"     # Imported variable.
 DEBUG="true"         # Imported variable.
 FREERDP_COMMAND=""   # Imported variable.
-MULTI_FLAG=""        # Set based on value of $MULTIMON.
 
 # PERMISSIONS AND DIRECTORIES
 SUDO=""         # Set to "sudo" if the user specifies '--system', or "" if the user specifies '--user'.
@@ -1043,9 +1041,6 @@ function waCheckRDPAccess() {
         /p:"$RDP_PASS" \
         /scale:"$RDP_SCALE" \
         +auto-reconnect \
-        +home-drive \
-        -wallpaper \
-        +dynamic-resolution \
         /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C type NUL > $TEST_PATH_WIN && tsdiscon" \
         /v:"$RDP_IP" &>"$FREERDP_LOG" &
 
@@ -1172,9 +1167,6 @@ function waFindInstalled() {
         /p:"$RDP_PASS" \
         /scale:"$RDP_SCALE" \
         +auto-reconnect \
-        +home-drive \
-        -wallpaper \
-        +dynamic-resolution \
         /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C "$BATCH_SCRIPT_PATH_WIN"" \
         /v:"$RDP_IP" &>"$FREERDP_LOG" &
 
@@ -1557,13 +1549,6 @@ function waInstall() {
 
     # Check for missing dependencies.
     waCheckInstallDependencies
-
-    # Update $MULTI_FLAG.
-    if [[ $MULTIMON == "true" ]]; then
-        MULTI_FLAG="/multimon"
-    else
-        MULTI_FLAG="+span"
-    fi
 
     # Update $RDP_SCALE.
     waFixScale


### PR DESCRIPTION
According to the FreeRDP matrix (see #525), some of our default arguments are outdated.

I've gone ahead and removed these flags and they can always be re-added by the user using `RDP_FLAGS`.

One of those flags which was apparently causing issues is `+span`, so I've removed the `MULTIMON` config variable (which added span if it was false, and removing that it would add a flag with a conditional which seems redundant)

Closes #525