### PR TITLE
doc: use openbsd-netcat on arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Install the required dependencies.
       ```
   - Arch Linux:
       ```bash
-      sudo pacman -Syu --needed -y curl dialog freerdp git iproute2 libnotify gnu-netcat
+      sudo pacman -Syu --needed -y curl dialog freerdp git iproute2 libnotify openbsd-netcat
       ```
   - OpenSUSE:
       ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -44,6 +44,6 @@ services:
       # NOTE: 'disk1' will be mounted as the main drive. THIS DISK WILL BE FORMATTED BY DOCKER.
       # All following disks (disk2, ...) WILL NOT BE FORMATTED.
       # - /dev/disk/by-id/<id>:/disk1
-      # - dev/disk/by-id/<id>:/disk2 
+      # - dev/disk/by-id/<id>:/disk2
     # group_add:      # uncomment this line and the next one for using rootless podman containers
     #   - keep-groups # to make /dev/kvm work with podman. needs "crun" installed, "runc" will not work! Add your user to the 'kvm' group or another that can access /dev/kvm.


### PR DESCRIPTION
Title. Apparently, the `openbsd-netcat` package works better than `gnu-netcat` with our args on Arch. This is consistent with all our other packages except Fedora. Maybe we should install an openbsd version of netcat there too?

Closes #508