### PR TITLE
add fish command to installing winapps

### DIFF
--- a/docs/libvirt.md
+++ b/docs/libvirt.md
@@ -756,3 +756,7 @@ Finally, restart the virtual machine, but **DO NOT** log in. Close the virtual m
 ```bash
 bash <(curl https://raw.githubusercontent.com/winapps-org/winapps/main/setup.sh)
 ```
+For fish terminal:
+```fish
+bash (curl https://raw.githubusercontent.com/winapps-org/winapps/main/setup.sh | psub )
+```


### PR DESCRIPTION
Bash command to install winapps only woks on bash. Added an additional command with fish syntax.