### PR TITLE
fix(nix): include icons dir for setup script

### DIFF
--- a/packages/winapps/default.nix
+++ b/packages/winapps/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
       "apps"
       "install"
       "bin"
+      "icons"
       "LICENSE.md"
       "COPYRIGHT.md"
       "setup.sh"


### PR DESCRIPTION
Added `icons` dir to nix derivation so `winapps-setup` (installed through the nix flake) succeeds