### PR TITLE
fix: Correct removable media path mapping for RDP drive redirection

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -665,7 +665,7 @@ function waRunCommand() {
             # Convert path from UNIX to Windows style.
             FILE_PATH=$(echo "$2" | sed \
                 -e 's|^'"${HOME}"'|\\\\tsclient\\home|' \
-                -e 's|^\('"${REMOVABLE_MEDIA//|/\\|}"'\)/[^/]*|\\\\tsclient\\media|' \
+                -e 's|^'"${REMOVABLE_MEDIA}"'|\\\\tsclient\\media|' \
                 -e 's|/|\\|g')
             dprint "UNIX_FILE_PATH: ${2}"
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"


### PR DESCRIPTION
## Problem

When passing a file path located on removable media (e.g., `/run/media/<user>/MyDrive/file.docx`) to a Windows application via WinApps, the path conversion logic incorrectly omits the `<user>` segment.

Specifically:
*   **Unix Path:** `/run/media/s/MyDrive/1.doc`
*   **FreeRDP Mount:** `/run/media` is mounted as `\\tsclient\media` in Windows.
*   **Expected Windows Path:** `\\tsclient\media\s\MyDrive\1.doc` (correctly reflecting the mount structure).
*   **Actual Windows Path Passed:** `\\tsclient\media\MyDrive\1.doc` (missing the `s` directory level).

This discrepancy occurs because the `sed` command used to convert the Unix path to a Windows path for RDP consumption consumes not just the `$REMOVABLE_MEDIA` prefix (`/run/media`) but also the first directory level *after* it (`/s`).

The problematic `sed` expression was:
`-e 's|^\('"${REMOVABLE_MEDIA//|/\\|}"'\)/[^/]*|\\\\tsclient\\media|'`
This matches `/run/media/s` and replaces it entirely with `\\tsclient\media`.

## Solution

This PR modifies the path conversion `sed` command within the `waRunCommand` function. It changes the rule for handling `$REMOVABLE_MEDIA` paths to only match and replace the `$REMOVABLE_MEDIA` prefix itself, leaving subsequent directory levels intact for the final `/|\\|g` substitution.

The updated `sed` expression is:
`-e 's|^'"${REMOVABLE_MEDIA}"'|\\\\tsclient\\media|'`
This now correctly matches only `/run/media` and replaces it with `\\tsclient\media`. The subsequent `/s`, `/MyDrive`, and `/1.doc` parts are then correctly converted to `\s`, `\MyDrive`, and `\1.doc` by the final `sed` rule.

This ensures that file paths passed to Windows applications accurately reflect their location within the RDP-mounted `\\tsclient\media` drive structure.