### PR TITLE
Update README.md with note for Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Install the required dependencies.
       ```
 
 > [!NOTE]
-> On Debian you need to enable the `backports` repository for the `freerdp3-x11` package to become available.
+> On Debian 12 (_"bookworm"_), you need to enable the `backports` repository for the `freerdp3-x11` package to become available.
 > For instructions, see https://backports.debian.org/Instructions.
 
   - Fedora/RHEL:


### PR DESCRIPTION
This is a minor PR that updates the `README` to make it clear the Debian instructions for installing `freerdp3-x11` are for Debian 12 (Bookworm). The current stable release (Trixie) has this package on its default repositories, so using backports isn't necessary anymore