### PR TITLE
fix: `Autopause` for `docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,7 @@ DEBUG="true"
 
 # [AUTOMATICALLY PAUSE WINDOWS]
 # NOTES:
-# - This is currently INCOMPATIBLE with 'docker' and 'manual'.
-# - See https://github.com/dockur/windows/issues/674
+# - This is currently INCOMPATIBLE with 'manual'.
 # DEFAULT VALUE: 'off'
 # VALID VALUES:
 # - 'on'

--- a/bin/winapps
+++ b/bin/winapps
@@ -707,7 +707,7 @@ function waCheckIdle() {
     local SUSPEND_WINDOWS=0
 
     # Prevent 'autopause' functionality with unsupported Windows backends.
-    if [ "$WAFLAVOR" != "manual" ] && [ "$WAFLAVOR" != "docker" ]; then
+    if [ "$WAFLAVOR" != "manual" ]; then
         # Check if there are no WinApps-related FreeRDP processes running.
         if ! ls "$APPDATA_PATH"/FreeRDP_Process_*.cproc &>/dev/null; then
             SUSPEND_WINDOWS=1


### PR DESCRIPTION
https://github.com/dockur/windows/issues/674 has been fixed.

We should therefore allow `AUTOPAUSE` for `docker` backend again.