### PR TITLE
fix: SVG color rendering issue in KDE.

### DIFF
--- a/install/windows.svg
+++ b/install/windows.svg
@@ -7,8 +7,5 @@
       <stop offset="1" stop-color="#7adcff"/>
     </linearGradient>
   </defs>
-  <style>
-    .s0 { fill: url(#g1) }
-  </style>
-  <path id="Windows" fill-rule="evenodd" class="s0" d="m228 0h746v974h-974v-746c0-125.9 102.1-228 228-228zm746 2048h-746c-125.9 0-228-102.1-228-228v-746h974zm846-2048c125.9 0 228 102.1 228 228v746h-974v-974zm228 1820c0 125.9-102.1 228-228 228h-746v-974h974z"/>
+  <path id="Windows" fill="url(#g1)" fill-rule="evenodd" class="s0" d="m228 0h746v974h-974v-746c0-125.9 102.1-228 228-228zm746 2048h-746c-125.9 0-228-102.1-228-228v-746h974zm846-2048c125.9 0 228 102.1 228 228v746h-974v-974zm228 1820c0 125.9-102.1 228-228 228h-746v-974h974z"/>
 </svg>


### PR DESCRIPTION
<img width="560" height="184" alt="Copie d'écran_20250907_113820" src="https://github.com/user-attachments/assets/cb41a13e-cefe-46b7-8d43-6f1b9fe779ff" />
<img width="788" height="234" alt="Copie d'écran_20250907_113651" src="https://github.com/user-attachments/assets/372f8583-2847-4c20-94a6-a50f8ccc0399" />

