### PR TITLE
fix: SVG color rendering issue in KDE

### DIFF
--- a/install/windows.svg
+++ b/install/windows.svg
@@ -7,8 +7,5 @@
       <stop offset="1" stop-color="#7adcff"/>
     </linearGradient>
   </defs>
-  <style>
-    .s0 { fill: url(#g1) }
-  </style>
-  <path id="Windows" fill-rule="evenodd" class="s0" d="m228 0h746v974h-974v-746c0-125.9 102.1-228 228-228zm746 2048h-746c-125.9 0-228-102.1-228-228v-746h974zm846-2048c125.9 0 228 102.1 228 228v746h-974v-974zm228 1820c0 125.9-102.1 228-228 228h-746v-974h974z"/>
+  <path id="Windows" fill="url(#g1)" fill-rule="evenodd" class="s0" d="m228 0h746v974h-974v-746c0-125.9 102.1-228 228-228zm746 2048h-746c-125.9 0-228-102.1-228-228v-746h974zm846-2048c125.9 0 228 102.1 228 228v746h-974v-974zm228 1820c0 125.9-102.1 228-228 228h-746v-974h974z"/>
 </svg>


### PR DESCRIPTION
Modify the SVG file with an inline fill attribute to resolve the black and white display issue in KDE. This ensures that the SVG displays correctly with the expected colors.

<img width="560" height="184" alt="Copie d'écran_20250907_113820" src="https://github.com/user-attachments/assets/15acfd8e-052b-42ef-bd67-a780b7061511" />
<img width="788" height="234" alt="Copie d'écran_20250907_113651" src="https://github.com/user-attachments/assets/f93d5386-beeb-42f6-b285-2a23fc959887" />
<img width="561" height="145" alt="Copie d'écran_20250907_120019" src="https://github.com/user-attachments/assets/482b2465-5956-4d7d-b6cd-97b58e142b6c" />


Signed-off-by: Voxay <vox@voxay.tech>