### PR TITLE
Update README with correct FreeRDP test command for Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,9 @@ BOOT_TIMEOUT="120"
     ```bash
     xfreerdp3 /u:"Your Windows Username" /p:"Your Windows Password" /v:192.168.122.2 /cert:tofu
 
+    # Or, if you are using Podman
+    podman unshare --rootless-netns xfreerdp3 /u:"Your Windows Username" /p:"Your Windows Password" /v:127.0.0.1 /cert:tofu
+
     # Or, if you installed FreeRDP using Flatpak
     flatpak run --command=xfreerdp com.freerdp.FreeRDP /u:"Your Windows Username" /p:"Your Windows Password" /v:192.168.122.2 /cert:tofu
     ```


### PR DESCRIPTION
I came across this issue while reading through #444. It may or may not address the issue, but since I don’t use Podman I’d appreciate it if someone could confirm whether the correction is accurate.