### PR TITLE
Add .gitattributes + Fix encodings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure Windows-friendly line endings and encoding for batch and registry files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.reg text eol=crlf working-tree-encoding=UTF-16LE-BOM

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,9 @@ repos:
         args: [ "775" ]
         files: (\.sh|winapps)$
       - id: forbid-crlf
+        exclude: '\.(bat|cmd|reg)$'
       - id: remove-crlf
+        exclude: '\.(bat|cmd|reg)$'
       - id: forbid-tabs
       - id: remove-tabs
         args: [ --whitespaces-count, "4" ]
@@ -32,6 +34,7 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: mixed-line-ending
+        exclude: '\.(bat|cmd|reg)$'
       - id: pretty-format-json
         args: [ "--autofix", "--no-sort-keys" ]
       - id: sort-simple-yaml

--- a/oem/install.bat
+++ b/oem/install.bat
@@ -40,7 +40,7 @@ if %ERRORLEVEL% equ 0 (
         echo [SUCCESS] Firewall changes applied successfully.
     ) else (
         echo [ERROR] Failed to apply firewall changes.
-        echo         Please manually enable Remote Desktop via 'Settings ► System ► Remote Desktop'.
+        echo         Please manually enable Remote Desktop via 'Settings --> System --> Remote Desktop'.
     )
 )
 


### PR DESCRIPTION
This PR addresses [issue #730](https://github.com/winapps-org/winapps/issues/730), which (I assume) was caused by incorrect handling of Windows file encodings and line endings.

Changes:
- Enforce CRLF line endings for all Windows-related files (`.bat`, `.cmd` and `.reg`) via `.gitattributes`
- Normalise `.reg` files to UTF-16LE with BOM, which is the expected format
- Remove unicode characters from `install.bat`, ensuring it is pure ASCII

Tested on a Windows 11 VM. Batch scripts execute as expected and registry imports succeed without errors.