### PR TITLE
[Small Fix] Fixed Converting Path from UNIX to WINDOWS

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -667,8 +667,8 @@ function waRunCommand() {
         else
             # Convert path from UNIX to Windows style.
             FILE_PATH=$(echo "$2" | sed \
-                -e 's|^'"${HOME}"'|\\\\tsclient\\home|' \
-                -e 's|^'"${REMOVABLE_MEDIA}"'|\\\\tsclient\\media|' \
+                -e 's|^'"${HOME}"'|\\\\tsclient\\home\\|' \
+                -e 's|^'"${REMOVABLE_MEDIA}"'|\\\\tsclient\\media\\|' \
                 -e 's|/|\\|g')
             dprint "UNIX_FILE_PATH: ${2}"
             dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"


### PR DESCRIPTION
Fixed UNIX path handling when the HOME environment variable ended with a trailing slash. 

Previously, the trailing slash was removed, which caused the home directory and the path to merge incorrectly. 
For example, with `HOME=/home/username/`, opening `/home/username/downloads/word.docx` would convert to: `/tsclient/homedownloads/word.docx`
This misconfigured the UNIX path and caused the file to fail to open. The extra slash does not affect cases where HOME is set to /home/username or ~ due to windows handling the extra slashes (more is better) 

Error before fix.
<img width="597" height="114" alt="image" src="https://github.com/user-attachments/assets/9c65bd0c-309a-4cc6-ad36-8d69a520a9c6" />