### PR TITLE
Add guidelines on using AI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,12 +18,12 @@ When using AI assistance, we expect contributors to understand the code that is 
 
 ### Other kinds of AI assistance
 
-Currently, [CodeRabbit](https://coderabbit.ai) is configured to review pull requests *on demand* when `@coderabbitai review` is commented on pull requests. 
+Currently, [CodeRabbit](https://coderabbit.ai) is configured to review pull requests *on demand* when `@coderabbitai review` is commented on pull requests.
 However, we ask of you to not use it for PRs of which you are the authors unless asked to. Additionally, please do not AI-generate descriptions for larger pull requests or reviews by hand. This does not include things like commit messages.
 
 ### AI "Art"
 
-We do not condone AI-generated "art", including AI-written and AI-produced tutorials, AI-generated icons for contributed applications.  
+We do not condone AI-generated "art", including AI-written and AI-produced tutorials, AI-generated icons for contributed applications.
 Additionally, please do not share these kinds of media on any official WinApps channel.
 
 ## Guidelines for pre-defined applications

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,25 @@ Thank you for contributing to winapps! Before you can contribute, we ask some th
 - Please follow code conventions enforced by `pre-commit`. To keep down CI usage, please run it locally before committing too.
   See <https://pre-commit.com> for installation, then run `pre-commit install` inside the `winapps` repository you cloned.
 
+## About using Artificial Intelligence for pull requests
+
+> [!IMPORTANT]
+> If you are using any kind of AI assistance to contribute to WinApps, it must be disclosed in the pull request.
+
+### AI-generated code
+
+When using AI assistance, we expect contributors to understand the code that is produced and be able to answer critical questions about it. It isn't a maintainers job to review a PR so broken that it requires significant rework to be acceptable. In a perfect world, AI assistance would produce equal or higher quality work than any human. That isn't the world we live in today, and in most cases it's generating slop. A good rule of thumb is that if another person can easily tell a pull request is AI-generated, it needs some more work.
+
+### Other kinds of AI assistance
+
+Currently, [CodeRabbit](https://coderabbit.ai) is configured to review pull requests *on demand* when `@coderabbitai review` is commented on pull requests. 
+However, we ask of you to not use it for PRs of which you are the authors unless asked to. Additionally, please do not AI-generate descriptions for larger pull requests or reviews by hand. This does not include things like commit messages.
+
+### AI "Art"
+
+We do not condone AI-generated "art", including AI-written and AI-produced tutorials, AI-generated icons for contributed applications.  
+Additionally, please do not share these kinds of media on any official WinApps channel.
+
 ## Guidelines for pre-defined applications
 
 Some pre-defined applications contain a header like:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ However, we ask of you to not use it for PRs of which you are the authors unless
 
 ### AI "Art"
 
-We do not condone AI-generated "art", including AI-written and AI-produced tutorials, AI-generated icons for contributed applications.
+We do not condone AI-generated "art", including AI-written and AI-produced tutorials, as well as AI-generated icons for contributed applications.
 Additionally, please do not share these kinds of media on any official WinApps channel.
 
 ## Guidelines for pre-defined applications


### PR DESCRIPTION
As discussed in #789, we want to restrict and clarify the use of AI in pull requests. This PR is a draft of that, mostly based on the [Ghostty contribution guidelines](https://github.com/ghostty-org/ghostty?tab=contributing-ov-file#ai-assistance-notice) and the [Curl AI guidelines](https://curl.se/dev/contribute.html).