### PR TITLE
winapps: Fix dprint called before APPDATA_PATH created.

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -785,11 +785,11 @@ function waTimeSync() {
 
 ### MAIN LOGIC ###
 #set -x # Enable for debugging.
+mkdir -p "$APPDATA_PATH"
 dprint "START"
 dprint "SCRIPT_DIR: ${SCRIPT_DIR_PATH}"
 dprint "SCRIPT_ARGS: ${*}"
 dprint "HOME_DIR: ${HOME}"
-mkdir -p "$APPDATA_PATH"
 waLastRun
 waLoadConfig
 waGetFreeRDPCommand


### PR DESCRIPTION
dprint is called before $APPDATA_PATH is created

first time executed: 
./winapps: line 161: /home/guille/.local/share/winapps/winapps.log: No such file or directory
./winapps: line 161: /home/guille/.local/share/winapps/winapps.log: No such file or directory
./winapps: line 161: /home/guille/.local/share/winapps/winapps.log: No such file or directory
./winapps: line 161: /home/guille/.local/share/winapps/winapps.log: No such file or directory
