### PR TITLE
fix: arch linux has deprecated gnu-netcat

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -620,7 +620,7 @@ function waCheckInstallDependencies() {
         echo "Red Hat/Fedora-based systems:"
         echo -e "  ${COMMAND_TEXT}sudo dnf install nmap-ncat${CLEAR_TEXT}"
         echo "Arch Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo pacman -S netcat${CLEAR_TEXT}"
+        echo -e "  ${COMMAND_TEXT}sudo pacman -S openbsd-netcat${CLEAR_TEXT}"
         echo "Gentoo Linux systems:"
         echo -e "  ${COMMAND_TEXT}sudo emerge --ask net-analyzer/netcat${CLEAR_TEXT}"
         echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
See https://gitlab.archlinux.org/archlinux/packaging/packages/gnu-netcat/-/issues/1
gnu-netcat only available in AUR: https://aur.archlinux.org/packages/gnu-netcat