### PR TITLE
Disable Windows 11 snap bar to avoid window snapping instability over RDP

### DIFF
--- a/oem/RDPApps.reg
+++ b/oem/RDPApps.reg
@@ -20,6 +20,10 @@ Windows Registry Editor Version 5.00
     [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services]
     "fAllowUnlistedRemotePrograms"=dword:00000001
 
+    ; Disable Windows 11 top-of-screen window snapping toolbar (snap bar)
+    [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+    "EnableSnapBar"=dword:00000000
+
     ; Disable automatic administrator logon at startup
     [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon]
     "AutoAdminLogon"="0"


### PR DESCRIPTION
This change disables the Windows 11 Snap Bar UI that appears when a window is dragged to the top of the screen. During RDP sessions, this behaviour is frequently triggered unintentionally, causing application windows to snap into preset layouts. This makes precise window positioning difficult and degrades overall usability in remote environments. The Snap Bar can be easily re-enabled at any time via Settings → System → Multitasking. On Windows 10, this additional registry key is ignored as the Snap Bar feature is not present.