### PR TITLE
Fixed a bug in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1865,8 +1865,9 @@ function waUninstall() {
     echo -e "${INFO_TEXT}You can remove these manually by running:${CLEAR_TEXT}"
     echo -e "${COMMAND_TEXT}rm -r $(dirname "$CONFIG_PATH")${CLEAR_TEXT}"
     echo -e "${COMMAND_TEXT}rm -r ${SOURCE_PATH}${CLEAR_TEXT}\n"
-# Print feedback.
-echo -e "${SUCCESS_TEXT}UNINSTALLATION COMPLETE.${CLEAR_TEXT}"
+
+    # Print feedback.
+    echo -e "${SUCCESS_TEXT}UNINSTALLATION COMPLETE.${CLEAR_TEXT}"
 }
 
 # Name: 'waAddApps'


### PR DESCRIPTION
**Summary:**
Improved the app management workflow. Previously, adding a new application required a full uninstallation and reinstallation of all existing apps. This PR adds the `--add-apps` option to allow for incremental updates.

**Changes:**

* Added `--add-apps` flag to `setup.sh`.
* Updated the help menu to reflect the new functionality for both user and system-wide installs.

**Usage Example:**

```bash
./setup.sh --help
#################################
#                                                                              #
#                            WinApps Install Wizard        #
#                                                                              #
#################################

Usage:
      --user                                        # Install WinApps and selected applications in /home/username
      --system                                      # Install WinApps and selected applications in /usr
      --user --setupAllOfficiallySupportedApps      # Install WinApps and all officially supported applications in /home/lunar
      --system --setupAllOfficiallySupportedApps    # Install WinApps and all officially supported applications in /usr
      --user --uninstall                            # Uninstall everything in /home/lunar
      --system --uninstall                          # Uninstall everything in /usr
      **--user --add-apps**                             # Add new applications to existing installation in /home/lunar
      **--system --add-apps**                           # Add new applications to existing installation in /usr
      --help                                        # Display this usage message.

```