### PR TITLE
Add MacOS Compatibility

### DIFF
--- a/Formula/winapps.rb
+++ b/Formula/winapps.rb
@@ -5,6 +5,8 @@ class Winapps < Formula
   version "1.0.0"
   license "GPL-3.0-only"
 
+  depends_on "bash"   # setup.sh uses bash 4+ features (declare -A, readarray)
+  depends_on "dialog" # interactive installer menus
   depends_on :macos
 
   def install

--- a/Formula/winapps.rb
+++ b/Formula/winapps.rb
@@ -5,8 +5,9 @@ class Winapps < Formula
   version "1.0.0"
   license "GPL-3.0-only"
 
-  depends_on "bash"   # setup.sh uses bash 4+ features (declare -A, readarray)
-  depends_on "dialog" # interactive installer menus
+  depends_on "bash"    # setup.sh uses bash 4+ features (declare -A, readarray)
+  depends_on "dialog"  # interactive installer menus
+  depends_on "freerdp" # installer uses xfreerdp (RemoteApp requires X11 backend, not SDL)
   depends_on :macos
 
   def install

--- a/Formula/winapps.rb
+++ b/Formula/winapps.rb
@@ -1,0 +1,49 @@
+class Winapps < Formula
+  desc "Run Windows apps on macOS via RDP RemoteApp"
+  homepage "https://github.com/dingyifei/winapps-macos"
+  url "https://github.com/dingyifei/winapps-macos.git", branch: "main"
+  version "1.0.0"
+  license "GPL-3.0-only"
+
+  depends_on :macos
+
+  def install
+    # Install main launcher
+    bin.install "bin/winapps"
+
+    # Install setup script
+    bin.install "setup.sh" => "winapps-setup"
+
+    # Install app definitions
+    pkgshare.install "apps"
+
+    # Install Windows-side scripts
+    pkgshare.install "install"
+  end
+
+  def caveats
+    <<~EOS
+      WinApps requires:
+      1. Microsoft "Windows App" from the Mac App Store
+      2. A Windows machine with RDP and RemoteApp enabled
+
+      Create a configuration file:
+        mkdir -p ~/.config/winapps
+        cat > ~/.config/winapps/winapps.conf << 'EOF'
+        RDP_IP=<your-windows-ip>
+        RDP_USER=<your-windows-user>
+        RDP_PASS=<your-windows-password>
+        EOF
+        chmod 600 ~/.config/winapps/winapps.conf
+
+      Then run the installer to detect Windows apps:
+        winapps-setup --user
+
+      See: #{homepage}/blob/main/docs/macOS.md
+    EOS
+  end
+
+  test do
+    assert_match "winapps", shell_output("#{bin}/winapps 2>&1", 1)
+  end
+end

--- a/Formula/winapps.rb
+++ b/Formula/winapps.rb
@@ -8,7 +8,7 @@ class Winapps < Formula
   depends_on "bash"    # setup.sh uses bash 4+ features (declare -A, readarray)
   depends_on "dialog"  # interactive installer menus
   depends_on "freerdp" # installer uses xfreerdp (RemoteApp requires X11 backend, not SDL)
-  depends_on :macos
+  depends_on "netcat"  # setup.sh uses nc to verify RDP port is open
 
   def install
     # Install main launcher

--- a/Formula/winapps.rb
+++ b/Formula/winapps.rb
@@ -1,7 +1,7 @@
 class Winapps < Formula
   desc "Run Windows apps on macOS via RDP RemoteApp"
-  homepage "https://github.com/dingyifei/winapps-macos"
-  url "https://github.com/dingyifei/winapps-macos.git", branch: "main"
+  homepage "https://github.com/winapps-org/winapps"
+  url "https://github.com/winapps-org/winapps.git", branch: "main"
   version "1.0.0"
   license "GPL-3.0-only"
 
@@ -42,7 +42,7 @@ class Winapps < Formula
       Then run the installer to detect Windows apps:
         winapps-setup --user
 
-      See: #{homepage}/blob/main/docs/macOS.md
+      See: https://github.com/winapps-org/winapps/blob/main/docs/macOS.md
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 <p align="center"><img align="center" width="700" src="./docs/readme/banner_light.svg#gh-light-mode-only"/></p>
 <hr>
 
-Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `KDE Plasma`, `GNOME` or `XFCE`, integrated seamlessly as if they were native to the OS.
+Run Windows applications (including [Microsoft 365](https://www.microsoft365.com/) and [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html)) on GNU/Linux with `KDE Plasma`, `GNOME` or `XFCE` and on **macOS**, integrated seamlessly as if they were native to the OS.
 
 <p align="center"><img src="./docs/readme/demo.png" width=1000 alt="WinApps Demonstration."></p>
 
 ## Underlying Mechanism
 WinApps works by:
-1. Running Windows in a `Docker`, `Podman` or `libvirt` virtual machine.
+1. Running Windows in a `Docker`, `Podman` or `libvirt` virtual machine (or connecting to any Windows machine with RDP enabled).
 2. Querying Windows for all installed applications.
-3. Creating shortcuts to selected Windows applications on the host GNU/Linux OS.
-4. Using [`FreeRDP`](https://www.freerdp.com/) as a backend to seamlessly render Windows applications alongside GNU/Linux applications.
+3. Creating shortcuts to selected Windows applications on the host OS.
+4. Using [`FreeRDP`](https://www.freerdp.com/) (Linux) or Microsoft ["Windows App"](https://apps.apple.com/app/windows-app/id1295203466) (macOS) as a backend to seamlessly render Windows applications alongside native applications.
 
 ## Additional Features
 - The GNU/Linux `/home` directory is accessible within Windows via the `\\tsclient\home` mount.
@@ -329,6 +329,18 @@ Contributing to the list of supported applications is encouraged through submiss
         </table>
 
 ## Installation
+
+### macOS
+
+For macOS installation and setup, see the [macOS guide](docs/macOS.md). WinApps on macOS uses Microsoft "Windows App" (free from the Mac App Store) instead of FreeRDP, and requires no virtual machine on the Mac — just a Windows machine with RDP enabled.
+
+```bash
+# Quick start (Homebrew)
+brew tap dingyifei/winapps
+brew install winapps
+```
+
+### GNU/Linux
 ### Step 1: Configure a Windows VM
 Both `Docker` and `Podman` are recommended backends for running the Windows virtual machine, as they facilitate an automated Windows installation process. WinApps is also compatible with `libvirt`. While this method requires considerably more manual configuration, it also provides greater virtual machine customisation options. All three methods leverage the `KVM` hypervisor, ensuring excellent virtual machine performance. Ultimately, the choice of backend depends on your specific use case.
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ For macOS installation and setup, see the [macOS guide](docs/macOS.md). WinApps 
 
 ```bash
 # Quick start (Homebrew)
-brew tap dingyifei/winapps
+brew tap winapps-org/winapps
 brew install winapps
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,16 +330,6 @@ Contributing to the list of supported applications is encouraged through submiss
 
 ## Installation
 
-### macOS
-
-For macOS installation and setup, see the [macOS guide](docs/macOS.md). WinApps on macOS uses Microsoft "Windows App" (free from the Mac App Store) instead of FreeRDP, and requires no virtual machine on the Mac — just a Windows machine with RDP enabled.
-
-```bash
-# Quick start (Homebrew)
-brew tap winapps-org/winapps
-brew install winapps
-```
-
 ### GNU/Linux
 ### Step 1: Configure a Windows VM
 Both `Docker` and `Podman` are recommended backends for running the Windows virtual machine, as they facilitate an automated Windows installation process. WinApps is also compatible with `libvirt`. While this method requires considerably more manual configuration, it also provides greater virtual machine customisation options. All three methods leverage the `KVM` hypervisor, ensuring excellent virtual machine performance. Ultimately, the choice of backend depends on your specific use case.
@@ -638,6 +628,17 @@ bash <(curl https://raw.githubusercontent.com/winapps-org/winapps/main/setup.sh)
 Once WinApps is installed, a list of additional arguments can be accessed by running `winapps-setup --help`.
 
 <img src="./docs/readme/installer.gif" width=1000 alt="WinApps Installer Animation.">
+
+### macOS
+
+For macOS installation and setup, see the [macOS guide](docs/macOS.md). WinApps on macOS uses Microsoft "Windows App" (free from the Mac App Store) instead of FreeRDP, and requires no virtual machine on the Mac — just a Windows machine with RDP enabled.
+
+```bash
+# Quick start (Homebrew)
+brew tap winapps-org/winapps
+brew install winapps
+```
+
 
 ## Adding Additional Pre-defined Applications
 Adding your own applications with custom icons and MIME types to the installer is easy. Simply copy one of the application configurations in the `apps` folder located within the WinApps repository, and:

--- a/bin/winapps
+++ b/bin/winapps
@@ -30,6 +30,9 @@ readonly SCRIPT_DIR_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && p
 readonly SLEEP_DETECT_PATH="${APPDATA_PATH}/last_activity"
 readonly SLEEP_MARKER="${APPDATA_PATH}/sleep_marker"
 
+# PLATFORM
+readonly PLATFORM="$(uname -s)"
+
 # OTHER
 readonly CONTAINER_NAME="WinApps" # FOR 'docker' AND 'podman' ONLY
 readonly RDP_PORT=3389
@@ -56,6 +59,7 @@ BOOT_TIMEOUT=120
 HIDEF="on"
 RDP_FLAGS_WINDOWS=""
 RDP_FLAGS_NON_WINDOWS=""
+TSCLIENT_HOME=""
 
 # OTHER
 FREERDP_PID=-1
@@ -90,66 +94,66 @@ function waThrowExit() {
     "$EC_MISSING_CONFIG")
         # Missing WinApps configuration file.
         dprint "ERROR: MISSING WINAPPS CONFIGURATION FILE. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "The WinApps configuration file is missing.\nPlease create a WinApps configuration file at '${CONFIG_PATH}'."
+        waNotify "WinApps" "The WinApps configuration file is missing.\nPlease create a WinApps configuration file at '${CONFIG_PATH}'." "dialog-error"
         ;;
     "$EC_MISSING_FREERDP")
         dprint "ERROR: FREERDP VERSION 3 IS NOT INSTALLED. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "FreeRDP version 3 is not installed."
+        waNotify "WinApps" "FreeRDP version 3 is not installed." "dialog-error"
         ;;
     "$EC_NOT_IN_GROUP")
         dprint "ERROR: USER NOT PART OF REQUIRED GROUPS. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "The user $(whoami) is not part of the required groups.
+        waNotify "WinApps" "The user $(whoami) is not part of the required groups.
 Please run:
     sudo usermod -a -G libvirt $(whoami)
-    sudo usermod -a -G kvm $(whoami)"
+    sudo usermod -a -G kvm $(whoami)" "dialog-error"
         ;;
     "$EC_FAIL_START")
         dprint "ERROR: WINDOWS FAILED TO START. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows failed to start."
+        waNotify "WinApps" "Windows failed to start." "dialog-error"
         ;;
     "$EC_FAIL_RESUME")
         dprint "ERROR: WINDOWS FAILED TO RESUME. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows failed to resume."
+        waNotify "WinApps" "Windows failed to resume." "dialog-error"
         ;;
     "$EC_FAIL_DESTROY")
         dprint "ERROR: FAILED TO FORCE STOP WINDOWS. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Failed to forcibly stop Windows."
+        waNotify "WinApps" "Failed to forcibly stop Windows." "dialog-error"
         ;;
     "$EC_SD_TIMEOUT")
         dprint "ERROR: WINDOWS TOOK TOO LONG TO SHUT DOWN. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows took too long to shut down."
+        waNotify "WinApps" "Windows took too long to shut down." "dialog-error"
         ;;
     "$EC_DIE_TIMEOUT")
         dprint "ERROR: WINDOWS TOOK TOO LONG TO DIE. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows took too long to die."
+        waNotify "WinApps" "Windows took too long to die." "dialog-error"
         ;;
     "$EC_RESTART_TIMEOUT")
         dprint "ERROR: WINDOWS TOOK TOO LONG TO RESTART. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows took too long to restart."
+        waNotify "WinApps" "Windows took too long to restart." "dialog-error"
         ;;
     "$EC_NOT_EXIST")
         dprint "ERROR: WINDOWS NONEXISTENT. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows VM named '${VM_NAME}' does not exist."
+        waNotify "WinApps" "Windows VM named '${VM_NAME}' does not exist." "dialog-error"
         ;;
     "$EC_UNKNOWN")
         dprint "ERROR: UNKNOWN CONTAINER ERROR. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Unknown Windows container error."
+        waNotify "WinApps" "Unknown Windows container error." "dialog-error"
         ;;
     "$EC_NO_IP")
         dprint "ERROR: WINDOWS UNREACHABLE. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Windows is unreachable.\nPlease ensure Windows is assigned an IP address."
+        waNotify "WinApps" "Windows is unreachable.\nPlease ensure Windows is assigned an IP address." "dialog-error"
         ;;
     "$EC_BAD_PORT")
         dprint "ERROR: RDP PORT CLOSED. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "The Windows RDP port '${RDP_PORT}' is closed.\nPlease ensure Remote Desktop is correctly configured on Windows."
+        waNotify "WinApps" "The Windows RDP port '${RDP_PORT}' is closed.\nPlease ensure Remote Desktop is correctly configured on Windows." "dialog-error"
         ;;
     "$EC_UNSUPPORTED_APP")
         dprint "ERROR: APPLICATION NOT FOUND. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Application not found.\nPlease ensure the program is correctly configured as an officially supported application."
+        waNotify "WinApps" "Application not found.\nPlease ensure the program is correctly configured as an officially supported application." "dialog-error"
         ;;
     "$EC_INVALID_FLAVOR")
         dprint "ERROR: INVALID FLAVOR. EXITING."
-        notify-send --expire-time=8000 --icon="dialog-error" --app-name="WinApps" --urgency="low" "WinApps" "Invalid WinApps flavor.\nPlease ensure 'docker', 'podman' or 'libvirt' are specified as the flavor in the WinApps configuration file."
+        waNotify "WinApps" "Invalid WinApps flavor.\nPlease ensure 'docker', 'podman' or 'libvirt' are specified as the flavor in the WinApps configuration file." "dialog-error"
         ;;
     esac
 
@@ -162,14 +166,63 @@ Please run:
 function dprint() {
     [ "$DEBUG" = "true" ] && echo "[$(date)-$RUNID] $1" >>"$LOG_PATH"
 }
+
+# Name: 'waNotify'
+# Role: Send cross-platform desktop notifications.
+# Args: $1=title, $2=body, $3=icon (default: dialog-info), $4=expire-time in ms (default: 8000)
+# Note: macOS 'osascript' does not support custom icons or expire times; notifications use the default app icon.
+function waNotify() {
+    local TITLE="$1"
+    local BODY="$2"
+    local ICON="${3:-dialog-info}"
+    local EXPIRE="${4:-8000}"
+    if [ "$PLATFORM" = "Darwin" ]; then
+        osascript -e "display notification \"$BODY\" with title \"$TITLE\"" 2>/dev/null || echo "$TITLE: $BODY"
+    else
+        notify-send --expire-time="$EXPIRE" --icon="$ICON" --app-name="WinApps" --urgency="low" "$TITLE" "$BODY"
+    fi
+}
+
+# Name: 'generate_rdp'
+# Role: Generate a .rdp file for macOS and return the path.
+function generate_rdp() {
+    local MODE="$1"          # "desktop" or "remoteapp"
+    local APP_NAME="$2"      # App name (for remoteapp)
+    local APP_EXE="$3"       # Windows executable (for remoteapp)
+    local APP_CMDLINE="$4"   # Command line args (optional)
+    local RDP_DIR="${TMPDIR:-/tmp}/winapps-rdp"
+    local RDP_FILE="${RDP_DIR}/${APP_NAME:-desktop}-$$.rdp"
+
+    mkdir -p "${RDP_DIR}"
+    {
+        echo "full address:s:${RDP_IP}:${RDP_PORT}"
+        echo "username:s:${RDP_USER}"
+        echo "domain:s:${RDP_DOMAIN}"
+        echo "drivestoredirect:s:*"
+        echo "redirectclipboard:i:1"
+        echo "autoreconnection enabled:i:1"
+        if [ "$MODE" = "remoteapp" ]; then
+            echo "remoteapplicationmode:i:1"
+            echo "remoteapplicationprogram:s:${APP_EXE}"
+            echo "remoteapplicationname:s:${APP_NAME}"
+            echo "remoteapplicationcmdline:s:${APP_CMDLINE}"
+            echo "disableremoteappcapscheck:i:1"
+        else
+            echo "desktopwidth:i:1920"
+            echo "desktopheight:i:1080"
+            echo "smart sizing:i:1"
+        fi
+    } > "${RDP_FILE}"
+    echo "${RDP_FILE}"
+}
+
 # Name: 'waFixRemovableMedia'
 # Role: If REMOVABLE_MEDIA is empty, default to /run/media (udisks default) and show a warning.
 function waFixRemovableMedia() {
     if [ -z "$REMOVABLE_MEDIA" ]; then
         REMOVABLE_MEDIA="/run/media"  # Default for udisks
         dprint "NOTICE: Using default REMOVABLE_MEDIA: $REMOVABLE_MEDIA"
-        notify-send --expire-time=3000 --icon="drive-removable-media" \
-            "WinApps Notice" "Using default removable media path: $REMOVABLE_MEDIA"
+        waNotify "WinApps Notice" "Using default removable media path: $REMOVABLE_MEDIA" "drive-removable-media" "3000"
     fi
 }
 # Name: 'waFixScale'
@@ -202,7 +255,7 @@ function waFixScale() {
 
         # Print feedback.
         dprint "WARNING: Unsupported RDP_SCALE value '${OLD_SCALE}'. Defaulting to '${RDP_SCALE}'."
-        notify-send --expire-time=4000 --icon="dialog-warning" --app-name="WinApps" --urgency="low" "WinApps" "Unsupported RDP_SCALE value '${OLD_SCALE}'.\nDefaulting to '${RDP_SCALE}'."
+        waNotify "WinApps" "Unsupported RDP_SCALE value '${OLD_SCALE}'.\nDefaulting to '${RDP_SCALE}'." "dialog-warning" "4000"
     fi
 }
 
@@ -217,10 +270,23 @@ function waLoadConfig() {
         waThrowExit $EC_MISSING_CONFIG
     fi
 
+    # Compute TSCLIENT_HOME if not set in config.
+    if [ -z "$TSCLIENT_HOME" ]; then
+        if [ "$PLATFORM" = "Darwin" ]; then
+            local VOL_NAME
+            VOL_NAME=$(diskutil info / | awk -F: '/Volume Name/{gsub(/^ +| +$/,"",$2); print $2}')
+            TSCLIENT_HOME="\\\\tsclient\\${VOL_NAME}$(echo "$HOME" | sed 's|/|\\|g')"
+        else
+            TSCLIENT_HOME='\\tsclient\home'
+        fi
+    fi
+
     # Update $RDP_SCALE.
     waFixScale
     # Update when $REMOVABLE_MEDIA is null
-    waFixRemovableMedia
+    if [ "$PLATFORM" != "Darwin" ]; then
+        waFixRemovableMedia
+    fi
     # Update $AUTOPAUSE_TIME.
     # RemoteApp RDP sessions take, at minimum, 20 seconds to be terminated by the Windows server.
     # Hence, subtract 20 from the timeout specified by the user, as a 'built in' timeout of 20 seconds will occur.
@@ -238,19 +304,33 @@ function waLastRun() {
 
     # Store the time this script was run last as a unix timestamp.
     if [ -f "$LASTRUN_PATH" ]; then
-        LAST_RUN_UNIX_TIME=$(stat -t -c %Y "$LASTRUN_PATH")
+        if [ "$PLATFORM" = "Darwin" ]; then
+            LAST_RUN_UNIX_TIME=$(stat -f %m "$LASTRUN_PATH")
+        else
+            LAST_RUN_UNIX_TIME=$(stat -t -c %Y "$LASTRUN_PATH")
+        fi
         dprint "LAST_RUN: ${LAST_RUN_UNIX_TIME}"
     fi
 
     # Update the file modification time with the current time.
     touch "$LASTRUN_PATH"
-    CURR_RUN_UNIX_TIME=$(stat -t -c %Y "$LASTRUN_PATH")
+    if [ "$PLATFORM" = "Darwin" ]; then
+        CURR_RUN_UNIX_TIME=$(stat -f %m "$LASTRUN_PATH")
+    else
+        CURR_RUN_UNIX_TIME=$(stat -t -c %Y "$LASTRUN_PATH")
+    fi
     dprint "THIS_RUN: ${CURR_RUN_UNIX_TIME}"
 }
 
 # Name: 'waGetFreeRDPCommand'
 # Role: Determine the correct FreeRDP command to use.
 function waGetFreeRDPCommand() {
+    # macOS uses .rdp files instead of FreeRDP.
+    if [ "$PLATFORM" = "Darwin" ]; then
+        dprint "macOS: using .rdp files via Microsoft Windows App"
+        return
+    fi
+
     # Declare variables.
     local FREERDP_MAJOR_VERSION="" # Stores the major version of the installed copy of FreeRDP.
 
@@ -330,28 +410,28 @@ function waCheckVMRunning() {
     if (virsh list --all --name | grep -Fxq -- "$VM_NAME"); then
         if (virsh list --state-shutoff --name | grep -Fxq -- "$VM_NAME"); then
             dprint "WINDOWS SHUT OFF. BOOTING WINDOWS."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+            waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
             NEEDED_BOOT=true
             virsh start "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_START
             if (virsh list --state-paused --name | grep -Fxq -- "$VM_NAME"); then
                 dprint "WINDOWS PAUSED. RESUMING WINDOWS."
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Resuming Windows."
+                waNotify "WinApps" "Resuming Windows." "dialog-info" "4000"
                 virsh resume "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_RESUME
             fi
         elif (virsh list --state-paused --name | grep -Fxq -- "$VM_NAME"); then
             dprint "WINDOWS PAUSED. RESUMING WINDOWS."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Resuming Windows."
+            waNotify "WinApps" "Resuming Windows." "dialog-info" "4000"
             virsh resume "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_RESUME
         elif (virsh list --state-other --name | grep -Fxq -- "$VM_NAME"); then
             if (virsh domstate "$VM_NAME" | grep -Fxq "in shutdown"); then
                 dprint "WINDOWS SHUTTING DOWN. WAITING."
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows is currently shutting down.\nIt will automatically restart once the shutdown process is complete."
+                waNotify "WinApps" "Windows is currently shutting down.\nIt will automatically restart once the shutdown process is complete." "dialog-info" "4000"
                 EXIT_STATUS=$EC_SD_TIMEOUT
                 while (( TIME_ELAPSED < TIME_LIMIT )); do
                     if (virsh list --state-shutoff --name | grep -Fxq -- "$VM_NAME"); then
                         EXIT_STATUS=0
                         dprint "WINDOWS SHUT OFF. BOOTING WINDOWS."
-                        notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+                        waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
                         virsh start "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_START
                         NEEDED_BOOT=true
                         break
@@ -361,27 +441,27 @@ function waCheckVMRunning() {
                 done
             elif (virsh domstate "$VM_NAME" | grep -Fxq "crashed"); then
                 dprint "WINDOWS CRASHED. DESTROYING WINDOWS."
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows experienced an unexpected crash.\nAttempting to restart Windows."
+                waNotify "WinApps" "Windows experienced an unexpected crash.\nAttempting to restart Windows." "dialog-info" "4000"
                 virsh destroy "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_DESTROY
                 if [ "$EXIT_STATUS" -eq 0 ]; then
                     dprint "WINDOWS DESTROYED. BOOTING WINDOWS."
-                    notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+                    waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
                     virsh start "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_START
                     NEEDED_BOOT=true
                 fi
             elif (virsh domstate "$VM_NAME" | grep -Fxq "dying"); then
                 dprint "WINDOWS DYING. WAITING."
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows is currently shutting down unexpectedly.\nIt will try to restart once the shutdown process finishes."
+                waNotify "WinApps" "Windows is currently shutting down unexpectedly.\nIt will try to restart once the shutdown process finishes." "dialog-info" "4000"
                 EXIT_STATUS=$EC_DIE_TIMEOUT
                 while (( TIME_ELAPSED < TIME_LIMIT )); do
                     if (virsh domstate "$VM_NAME" | grep -Fxq "crashed"); then
                         EXIT_STATUS=0
                         dprint "WINDOWS CRASHED. DESTROYING WINDOWS."
-                        notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows experienced an unexpected crash.\nAttempting to restart Windows."
+                        waNotify "WinApps" "Windows experienced an unexpected crash.\nAttempting to restart Windows." "dialog-info" "4000"
                         virsh destroy "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_DESTROY
                         if [ "$EXIT_STATUS" -eq 0 ]; then
                             dprint "WINDOWS DESTROYED. BOOTING WINDOWS."
-                            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+                            waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
                             virsh start "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_START
                             NEEDED_BOOT=true
                         fi
@@ -389,7 +469,7 @@ function waCheckVMRunning() {
                     elif (virsh list --state-shutoff --name | grep -Fxq -- "$VM_NAME"); then
                         EXIT_STATUS=0
                         dprint "WINDOWS SHUT OFF. BOOTING WINDOWS."
-                        notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+                        waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
                         virsh start "$VM_NAME" &>/dev/null || EXIT_STATUS=$EC_FAIL_START
                         NEEDED_BOOT=true
                         break
@@ -412,7 +492,7 @@ function waCheckVMRunning() {
     # Wait for VM to be fully ready
     if [[ "$NEEDED_BOOT" == "true" ]]; then
         dprint "WAITING FOR VM TO BE FULLY READY..."
-        notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Waiting for Windows to be ready..."
+        waNotify "WinApps" "Waiting for Windows to be ready..." "dialog-info" "4000"
 
         TIME_ELAPSED=0
 
@@ -422,7 +502,7 @@ function waCheckVMRunning() {
                 # Try to connect to RDP port to verify it's ready
                 if timeout 1 bash -c ">/dev/tcp/$RDP_IP/$RDP_PORT" 2>/dev/null; then
                     dprint "VM IS READY"
-                    notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows is ready."
+                    waNotify "WinApps" "Windows is ready." "dialog-info" "4000"
                     # Add a delay after Windows is ready
                     if [ "$NEEDED_BOOT" = "true" ]; then
                         sleep 10
@@ -436,14 +516,14 @@ function waCheckVMRunning() {
 
             # Show progress every 30 seconds
             if (( TIME_ELAPSED % 30 == 0 )); then
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Still waiting for Windows to be ready... ($TIME_ELAPSED seconds elapsed)"
+                waNotify "WinApps" "Still waiting for Windows to be ready... ($TIME_ELAPSED seconds elapsed)" "dialog-info" "4000"
             fi
         done
 
         # If we timed out waiting for the VM
         if (( TIME_ELAPSED >= BOOT_TIMEOUT )); then
             dprint "TIMEOUT WAITING FOR VM TO BE READY"
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Timeout waiting for Windows to be ready. Please try again."
+            waNotify "WinApps" "Timeout waiting for Windows to be ready. Please try again." "dialog-info" "4000"
             waThrowExit $EC_FAIL_START
         fi
     fi
@@ -476,19 +556,19 @@ function waCheckContainerRunning() {
     case "$CONTAINER_STATE" in
         "created")
             dprint "WINDOWS CREATED. BOOTING WINDOWS."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+            waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
             $COMPOSE_COMMAND --file "$COMPOSE_PATH" start &>/dev/null
             NEEDED_BOOT=true
             ;;
         "restarting")
             dprint "WINDOWS RESTARTING. WAITING."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows is currently restarting. Please wait."
+            waNotify "WinApps" "Windows is currently restarting. Please wait." "dialog-info" "4000"
             EXIT_STATUS=$EC_RESTART_TIMEOUT
             while (( TIME_ELAPSED < TIME_LIMIT )); do
                 if [[ $("$WAFLAVOR" inspect --format='{{.State.Status}}' "$CONTAINER_NAME") == "running" ]]; then
                     EXIT_STATUS=0
                     dprint "WINDOWS RESTARTED."
-                    notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Restarted Windows."
+                    waNotify "WinApps" "Restarted Windows." "dialog-info" "4000"
                     NEEDED_BOOT=true
                     break
                 fi
@@ -498,18 +578,18 @@ function waCheckContainerRunning() {
             ;;
         "paused")
             dprint "WINDOWS PAUSED. RESUMING WINDOWS."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Resuming Windows."
+            waNotify "WinApps" "Resuming Windows." "dialog-info" "4000"
             $COMPOSE_COMMAND --file "$COMPOSE_PATH" unpause &>/dev/null
             ;;
         "exited")
             dprint "WINDOWS SHUT OFF. BOOTING WINDOWS."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Booting Windows."
+            waNotify "WinApps" "Booting Windows." "dialog-info" "4000"
             $COMPOSE_COMMAND --file "$COMPOSE_PATH" start &>/dev/null
             NEEDED_BOOT=true
             ;;
         "dead")
             dprint "WINDOWS DEAD. RECREATING WINDOWS CONTAINER."
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Re-creating and booting Windows."
+            waNotify "WinApps" "Re-creating and booting Windows." "dialog-info" "4000"
             $COMPOSE_COMMAND --file "$COMPOSE_PATH" down &>/dev/null && $COMPOSE_COMMAND --file "$COMPOSE_PATH" up -d &>/dev/null
             NEEDED_BOOT=true
             ;;
@@ -524,7 +604,7 @@ function waCheckContainerRunning() {
     # Wait for container to be fully ready
     if [[ "$CONTAINER_STATE" == "created" || "$CONTAINER_STATE" == "exited" || "$CONTAINER_STATE" == "dead" || "$CONTAINER_STATE" == "restarting" ]]; then
         dprint "WAITING FOR CONTAINER TO BE FULLY READY..."
-        notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Waiting for Windows to be ready..."
+        waNotify "WinApps" "Waiting for Windows to be ready..." "dialog-info" "4000"
 
         TIME_ELAPSED=0
 
@@ -534,7 +614,7 @@ function waCheckContainerRunning() {
                 # Try to connect to RDP port to verify it's ready
                 if timeout 1 bash -c ">/dev/tcp/$RDP_IP/$RDP_PORT" 2>/dev/null; then
                     dprint "CONTAINER IS READY"
-                    notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Windows is ready."
+                    waNotify "WinApps" "Windows is ready." "dialog-info" "4000"
                     # Add a delay after Windows is ready
                     if [ "$NEEDED_BOOT" = "true" ]; then
                         sleep 10
@@ -548,14 +628,14 @@ function waCheckContainerRunning() {
 
             # Show progress every 30 seconds
             if (( TIME_ELAPSED % 30 == 0 )); then
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Still waiting for Windows to be ready... ($TIME_ELAPSED seconds elapsed)"
+                waNotify "WinApps" "Still waiting for Windows to be ready... ($TIME_ELAPSED seconds elapsed)" "dialog-info" "4000"
             fi
         done
 
         # If we timed out waiting for the container
         if (( TIME_ELAPSED >= BOOT_TIMEOUT )); then
             dprint "TIMEOUT WAITING FOR CONTAINER TO BE READY"
-            notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Timeout waiting for Windows to be ready. Please try again."
+            waNotify "WinApps" "Timeout waiting for Windows to be ready. Please try again." "dialog-info" "4000"
             waThrowExit $EC_FAIL_START
         fi
     fi
@@ -577,7 +657,7 @@ function waCheckPortOpen() {
 
         while (( TIME_ELAPSED < TIME_LIMIT )); do
             if [ "$TIME_ELAPSED" -eq "$TIME_INTERVAL" ]; then
-                notify-send --expire-time=4000 --icon="dialog-info" --app-name="WinApps" --urgency="low" "WinApps" "Requesting Windows IP address..."
+                waNotify "WinApps" "Requesting Windows IP address..." "dialog-info" "4000"
             fi
             RDP_IP=$(ip neigh show | grep "$VM_MAC" | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}") # VM IP address.
             [ -n "$RDP_IP" ] && break
@@ -589,7 +669,11 @@ function waCheckPortOpen() {
     fi
 
     # Check for an open RDP port.
-    timeout 10 nc -z "$RDP_IP" "$RDP_PORT" &>/dev/null || waThrowExit "$EC_BAD_PORT"
+    if [ "$PLATFORM" = "Darwin" ]; then
+        nc -z -w 10 "$RDP_IP" "$RDP_PORT" &>/dev/null || waThrowExit "$EC_BAD_PORT"
+    else
+        timeout 10 nc -z "$RDP_IP" "$RDP_PORT" &>/dev/null || waThrowExit "$EC_BAD_PORT"
+    fi
 }
 
 # Name: 'waRunCommand'
@@ -598,6 +682,44 @@ function waRunCommand() {
     # Declare variables.
     local ICON=""
     local FILE_PATH=""
+
+    # macOS: generate .rdp files and open with Microsoft "Windows App".
+    if [ "$PLATFORM" = "Darwin" ]; then
+        local RDP_FILE=""
+        if [ "$1" = "windows" ]; then
+            dprint "MACOS WINDOWS DESKTOP"
+            RDP_FILE=$(generate_rdp "desktop" "windows" "" "")
+        elif [ "$1" = "manual" ]; then
+            dprint "MACOS MANUAL: ${2}"
+            RDP_FILE=$(generate_rdp "remoteapp" "manual" "$2" "")
+        else
+            # Named app — resolve info file.
+            if [ -e "${SCRIPT_DIR_PATH}/../apps/${1}/info" ]; then
+                source "${SCRIPT_DIR_PATH}/../apps/${1}/info"
+            elif [ -e "${APPDATA_PATH}/apps/${1}/info" ]; then
+                source "${APPDATA_PATH}/apps/${1}/info"
+            elif [ -e "${SYS_APP_PATH}/apps/${1}/info" ]; then
+                source "${SYS_APP_PATH}/apps/${1}/info"
+            else
+                waThrowExit "$EC_UNSUPPORTED_APP"
+            fi
+
+            local APP_CMDLINE=""
+            if [ -n "$2" ]; then
+                # Convert UNIX path to Windows tsclient path.
+                FILE_PATH=$(echo "$2" | sed -e 's|^'"${HOME}"'|'"${TSCLIENT_HOME}"'|' -e 's|/|\\|g')
+                dprint "UNIX_FILE_PATH: ${2}"
+                dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
+                APP_CMDLINE="$FILE_PATH"
+            fi
+            dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
+            RDP_FILE=$(generate_rdp "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
+        fi
+
+        dprint "RDP_FILE: ${RDP_FILE}"
+        open "$RDP_FILE"
+        return
+    fi
 
     # Run option.
     if [ "$1" = "windows" ]; then
@@ -737,7 +859,7 @@ function waCheckIdle() {
         # Hibernate/Pause Windows.
         if [ "$SUSPEND_WINDOWS" -eq 1 ]; then
             dprint "IDLE FOR ${AUTOPAUSE_TIME} SECONDS. SUSPENDING WINDOWS."
-            notify-send --expire-time=8000 --icon="info" --app-name="WinApps" --urgency="low" "WinApps" "Pausing Windows due to inactivity."
+            waNotify "WinApps" "Pausing Windows due to inactivity." "info" "8000"
             if [ "$WAFLAVOR" = "docker" ]; then
                 docker compose --file "$COMPOSE_PATH" pause &>/dev/null
             elif [ "$WAFLAVOR" = "podman" ]; then
@@ -752,6 +874,9 @@ function waCheckIdle() {
 # Name: 'waTimeSync'
 # Role: Detect if system went to sleep by comparing uptime progression, then sync time in Windows VM
 function waTimeSync() {
+    # macOS does not have /proc/uptime; skip sleep detection.
+    if [ "$PLATFORM" = "Darwin" ]; then return; fi
+
     local CURRENT_TIME
     local CURRENT_UPTIME
     local STORED_TIME=0
@@ -802,6 +927,10 @@ dprint "SCRIPT_ARGS: ${*}"
 dprint "HOME_DIR: ${HOME}"
 waLastRun
 waLoadConfig
+
+# macOS always uses 'manual' flavor (no VM management, just RDP to a remote Windows machine).
+if [ "$PLATFORM" = "Darwin" ]; then WAFLAVOR="manual"; fi
+
 waGetFreeRDPCommand
 
 # If using podman backend, modify the FreeRDP command to enter a new namespace.

--- a/bin/winapps
+++ b/bin/winapps
@@ -32,8 +32,8 @@ readonly SLEEP_DETECT_PATH="${APPDATA_PATH}/last_activity"
 readonly SLEEP_MARKER="${APPDATA_PATH}/sleep_marker"
 
 # PLATFORM
-PLATFORM="$(uname -s)"
-readonly PLATFORM
+# shellcheck disable=SC2155 # Silence warnings regarding masking return values through simultaneous declaration and assignment.
+readonly PLATFORM="$(uname -s)"
 
 # OTHER
 readonly CONTAINER_NAME="WinApps" # FOR 'docker' AND 'podman' ONLY
@@ -185,9 +185,9 @@ function waNotify() {
     fi
 }
 
-# Name: 'generate_rdp'
+# Name: 'waGenerateRdpFiles'
 # Role: Generate a .rdp file for macOS and return the path.
-function generate_rdp() {
+function waGenerateRdpFiles() {
     local MODE="$1"          # "desktop" or "remoteapp"
     local APP_NAME="$2"      # App name (for remoteapp)
     local APP_EXE="$3"       # Windows executable (for remoteapp)
@@ -690,10 +690,10 @@ function waRunCommand() {
         local RDP_FILE=""
         if [ "$1" = "windows" ]; then
             dprint "MACOS WINDOWS DESKTOP"
-            RDP_FILE=$(generate_rdp "desktop" "windows" "" "")
+            RDP_FILE=$(waGenerateRdpFiles "desktop" "windows" "" "")
         elif [ "$1" = "manual" ]; then
             dprint "MACOS MANUAL: ${2}"
-            RDP_FILE=$(generate_rdp "remoteapp" "manual" "$2" "")
+            RDP_FILE=$(waGenerateRdpFiles "remoteapp" "manual" "$2" "")
         else
             # Named app — resolve info file.
             if [ -e "${SCRIPT_DIR_PATH}/../apps/${1}/info" ]; then
@@ -724,7 +724,7 @@ function waRunCommand() {
                 APP_CMDLINE="\"${FILE_PATH}\""
             fi
             dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
-            RDP_FILE=$(generate_rdp "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
+            RDP_FILE=$(waGenerateRdpFiles "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
         fi
 
         dprint "RDP_FILE: ${RDP_FILE}"

--- a/bin/winapps
+++ b/bin/winapps
@@ -715,13 +715,10 @@ function waRunCommand() {
             local APP_CMDLINE=""
             if [ -n "$2" ]; then
                 # Convert UNIX path to Windows tsclient path.
-                # Use bash parameter expansion instead of sed to avoid
-                # backslash escape interpretation in TSCLIENT_HOME.
-                FILE_PATH="${2/#${HOME}/${TSCLIENT_HOME}}"
-                FILE_PATH="${FILE_PATH//\//\\}"
+                FILE_PATH=$(echo "$2" | sed -e 's|^'"${HOME}"'|'"${TSCLIENT_HOME}"'|' -e 's|/|\\|g')
                 dprint "UNIX_FILE_PATH: ${2}"
                 dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
-                APP_CMDLINE="\"${FILE_PATH}\""
+                APP_CMDLINE="$FILE_PATH"
             fi
             dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
             RDP_FILE=$(waGenerateRdpFiles "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")

--- a/bin/winapps
+++ b/bin/winapps
@@ -21,6 +21,7 @@ readonly EC_INVALID_FLAVOR=15
 # PATHS
 readonly APPDATA_PATH="${HOME}/.local/share/winapps"
 readonly SYS_APP_PATH="/usr/local/share/winapps"
+readonly BREW_APP_PATH="${SCRIPT_DIR_PATH}/../share/winapps"
 readonly LASTRUN_PATH="${APPDATA_PATH}/lastrun"
 readonly LOG_PATH="${APPDATA_PATH}/winapps.log"
 readonly CONFIG_PATH="${HOME}/.config/winapps/winapps.conf"
@@ -695,10 +696,16 @@ function waRunCommand() {
         else
             # Named app — resolve info file.
             if [ -e "${SCRIPT_DIR_PATH}/../apps/${1}/info" ]; then
+                # shellcheck source=/dev/null # Exclude app info file from being checked by ShellCheck.
                 source "${SCRIPT_DIR_PATH}/../apps/${1}/info"
+            elif [ -e "${BREW_APP_PATH}/apps/${1}/info" ]; then
+                # shellcheck source=/dev/null # Exclude app info file from being checked by ShellCheck.
+                source "${BREW_APP_PATH}/apps/${1}/info"
             elif [ -e "${APPDATA_PATH}/apps/${1}/info" ]; then
+                # shellcheck source=/dev/null # Exclude app info file from being checked by ShellCheck.
                 source "${APPDATA_PATH}/apps/${1}/info"
             elif [ -e "${SYS_APP_PATH}/apps/${1}/info" ]; then
+                # shellcheck source=/dev/null # Exclude app info file from being checked by ShellCheck.
                 source "${SYS_APP_PATH}/apps/${1}/info"
             else
                 waThrowExit "$EC_UNSUPPORTED_APP"
@@ -765,6 +772,10 @@ function waRunCommand() {
             # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.
             source "${SCRIPT_DIR_PATH}/../apps/${1}/info"
             ICON="${SCRIPT_DIR_PATH}/../apps/${1}/icon.svg"
+        elif [ -e "${BREW_APP_PATH}/apps/${1}/info" ]; then
+            # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.
+            source "${BREW_APP_PATH}/apps/${1}/info"
+            ICON="${BREW_APP_PATH}/apps/${1}/icon.svg"
         elif [ -e "${APPDATA_PATH}/apps/${1}/info" ]; then
             # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.
             source "${APPDATA_PATH}/apps/${1}/info"

--- a/bin/winapps
+++ b/bin/winapps
@@ -32,7 +32,8 @@ readonly SLEEP_DETECT_PATH="${APPDATA_PATH}/last_activity"
 readonly SLEEP_MARKER="${APPDATA_PATH}/sleep_marker"
 
 # PLATFORM
-readonly PLATFORM="$(uname -s)"
+PLATFORM="$(uname -s)"
+readonly PLATFORM
 
 # OTHER
 readonly CONTAINER_NAME="WinApps" # FOR 'docker' AND 'podman' ONLY
@@ -276,7 +277,7 @@ function waLoadConfig() {
         if [ "$PLATFORM" = "Darwin" ]; then
             local VOL_NAME
             VOL_NAME=$(diskutil info / | awk -F: '/Volume Name/{gsub(/^ +| +$/,"",$2); print $2}')
-            TSCLIENT_HOME="\\\\tsclient\\${VOL_NAME}$(echo "$HOME" | sed 's|/|\\|g')"
+            TSCLIENT_HOME="\\\\tsclient\\${VOL_NAME}${HOME//\//\\}"
         else
             TSCLIENT_HOME='\\tsclient\home'
         fi

--- a/bin/winapps
+++ b/bin/winapps
@@ -184,9 +184,9 @@ function waNotify() {
     fi
 }
 
-# Name: 'waGenerateRdpFiles'
+# Name: 'waGenerateRdpFile'
 # Role: Generate a .rdp file for macOS and return the path.
-function waGenerateRdpFiles() {
+function waGenerateRdpFile() {
     local MODE="$1"          # "desktop" or "remoteapp"
     local APP_NAME="$2"      # App name (for remoteapp)
     local APP_EXE="$3"       # Windows executable (for remoteapp)
@@ -679,10 +679,10 @@ function waRunCommand() {
         local RDP_FILE=""
         if [ "$1" = "windows" ]; then
             dprint "MACOS WINDOWS DESKTOP"
-            RDP_FILE=$(waGenerateRdpFiles "desktop" "windows" "" "")
+            RDP_FILE=$(waGenerateRdpFile "desktop" "windows" "" "")
         elif [ "$1" = "manual" ]; then
             dprint "MACOS MANUAL: ${2}"
-            RDP_FILE=$(waGenerateRdpFiles "remoteapp" "manual" "$2" "")
+            RDP_FILE=$(waGenerateRdpFile "remoteapp" "manual" "$2" "")
         else
             # Named app — resolve info file.
             if [ -e "${SCRIPT_DIR_PATH}/../apps/${1}/info" ]; then
@@ -703,7 +703,7 @@ function waRunCommand() {
 
             local APP_CMDLINE=""
             dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
-            RDP_FILE=$(waGenerateRdpFiles "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
+            RDP_FILE=$(waGenerateRdpFile "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
         fi
 
         dprint "RDP_FILE: ${RDP_FILE}"

--- a/bin/winapps
+++ b/bin/winapps
@@ -61,7 +61,6 @@ BOOT_TIMEOUT=120
 HIDEF="on"
 RDP_FLAGS_WINDOWS=""
 RDP_FLAGS_NON_WINDOWS=""
-TSCLIENT_HOME=""
 
 # OTHER
 FREERDP_PID=-1
@@ -272,16 +271,6 @@ function waLoadConfig() {
         waThrowExit $EC_MISSING_CONFIG
     fi
 
-    # Compute TSCLIENT_HOME if not set in config.
-    if [ -z "$TSCLIENT_HOME" ]; then
-        if [ "$PLATFORM" = "Darwin" ]; then
-            local VOL_NAME
-            VOL_NAME=$(diskutil info / | awk -F: '/Volume Name/{gsub(/^ +| +$/,"",$2); print $2}')
-            TSCLIENT_HOME="\\\\tsclient\\${VOL_NAME}${HOME//\//\\}"
-        else
-            TSCLIENT_HOME='\\tsclient\home'
-        fi
-    fi
 
     # Update $RDP_SCALE.
     waFixScale
@@ -713,13 +702,6 @@ function waRunCommand() {
             fi
 
             local APP_CMDLINE=""
-            if [ -n "$2" ]; then
-                # Convert UNIX path to Windows tsclient path.
-                FILE_PATH=$(echo "$2" | sed -e 's|^'"${HOME}"'|'"${TSCLIENT_HOME}"'|' -e 's|/|\\|g')
-                dprint "UNIX_FILE_PATH: ${2}"
-                dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
-                APP_CMDLINE="$FILE_PATH"
-            fi
             dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
             RDP_FILE=$(waGenerateRdpFiles "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")
         fi

--- a/bin/winapps
+++ b/bin/winapps
@@ -714,10 +714,13 @@ function waRunCommand() {
             local APP_CMDLINE=""
             if [ -n "$2" ]; then
                 # Convert UNIX path to Windows tsclient path.
-                FILE_PATH=$(echo "$2" | sed -e 's|^'"${HOME}"'|'"${TSCLIENT_HOME}"'|' -e 's|/|\\|g')
+                # Use bash parameter expansion instead of sed to avoid
+                # backslash escape interpretation in TSCLIENT_HOME.
+                FILE_PATH="${2/#${HOME}/${TSCLIENT_HOME}}"
+                FILE_PATH="${FILE_PATH//\//\\}"
                 dprint "UNIX_FILE_PATH: ${2}"
                 dprint "WINDOWS_FILE_PATH: ${FILE_PATH}"
-                APP_CMDLINE="$FILE_PATH"
+                APP_CMDLINE="\"${FILE_PATH}\""
             fi
             dprint "MACOS APP: ${1} (${WIN_EXECUTABLE})"
             RDP_FILE=$(generate_rdp "remoteapp" "$1" "$WIN_EXECUTABLE" "$APP_CMDLINE")

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -5,9 +5,10 @@ Run Windows applications on macOS via RDP RemoteApp, using the system RDP client
 ## Prerequisites
 
 1. **Microsoft "Windows App"** (free) from the [Mac App Store](https://apps.apple.com/app/windows-app/id1295203466)
-2. **`dialog`** — required for the interactive installer (`brew install dialog`)
-3. A **Windows machine with RDP enabled** (VM, remote server, or local Parallels/UTM)
-4. **RDP RemoteApp configured** on the Windows machine (merge `install/RDPApps.reg`)
+2. **FreeRDP** — used by the installer for app scanning (`brew install freerdp`)
+3. **`dialog`** — required for the interactive installer (`brew install dialog`)
+4. A **Windows machine with RDP enabled** (VM, remote server, or local Parallels/UTM)
+5. **RDP RemoteApp configured** on the Windows machine (merge `install/RDPApps.reg`)
 
 ## Installation
 
@@ -96,8 +97,12 @@ winapps manual "C:\Windows\System32\notepad.exe"
 
 ## How It Works
 
-On macOS, WinApps generates `.rdp` files dynamically and opens them with the system `open` command, which delegates to Microsoft "Windows App". This avoids the FreeRDP/XQuartz dependency chain.
+WinApps uses two different RDP approaches on macOS:
 
+- **Day-to-day usage** (`bin/winapps`): Generates `.rdp` files and opens them with Microsoft "Windows App" via the system `open` command. This provides the best RemoteApp display experience.
+- **Installer/scanner** (`setup.sh`): Uses FreeRDP (`sdl-freerdp3`) to execute commands on the Windows machine (app scanning, RDP access tests). FreeRDP's `/app:` parameter enables server-side command execution, which "Windows App" does not support. The scan runs in the background with output redirected to a log file.
+
+Day-to-day:
 - `winapps word` generates a temporary `.rdp` file with RemoteApp settings and opens it
 - `winapps windows` generates a full desktop `.rdp` file
 - Files passed as arguments are mapped through `\\tsclient\<Volume Name>\Users\...` (drive redirection)

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -5,8 +5,9 @@ Run Windows applications on macOS via RDP RemoteApp, using the system RDP client
 ## Prerequisites
 
 1. **Microsoft "Windows App"** (free) from the [Mac App Store](https://apps.apple.com/app/windows-app/id1295203466)
-2. A **Windows machine with RDP enabled** (VM, remote server, or local Parallels/UTM)
-3. **RDP RemoteApp configured** on the Windows machine (merge `install/RDPApps.reg`)
+2. **`dialog`** — required for the interactive installer (`brew install dialog`)
+3. A **Windows machine with RDP enabled** (VM, remote server, or local Parallels/UTM)
+4. **RDP RemoteApp configured** on the Windows machine (merge `install/RDPApps.reg`)
 
 ## Installation
 

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -1,0 +1,124 @@
+# WinApps on macOS
+
+Run Windows applications on macOS via RDP RemoteApp, using the system RDP client (Microsoft "Windows App").
+
+## Prerequisites
+
+1. **Microsoft "Windows App"** (free) from the [Mac App Store](https://apps.apple.com/app/windows-app/id1295203466)
+2. A **Windows machine with RDP enabled** (VM, remote server, or local Parallels/UTM)
+3. **RDP RemoteApp configured** on the Windows machine (merge `install/RDPApps.reg`)
+
+## Installation
+
+### Via Homebrew (recommended)
+
+```bash
+brew tap dingyifei/winapps
+brew install winapps
+```
+
+### Manual
+
+```bash
+git clone https://github.com/dingyifei/winapps-macos.git
+cd winapps-macos
+```
+
+## Configuration
+
+Create the config file:
+
+```bash
+mkdir -p ~/.config/winapps
+cat > ~/.config/winapps/winapps.conf << 'EOF'
+RDP_IP=192.168.1.100
+RDP_USER=MyWindowsUser
+RDP_PASS=MyPassword
+RDP_DOMAIN=WORKGROUP
+EOF
+chmod 600 ~/.config/winapps/winapps.conf
+```
+
+Set `RDP_IP` to your Windows machine's IP address. Unlike Linux, macOS does not support KVM auto-detection, so `RDP_IP` is **required**.
+
+### Optional: `TSCLIENT_HOME`
+
+WinApps auto-detects your macOS volume name (e.g., `Macintosh HD`) to compute the correct `\\tsclient\...` path for file passthrough. If auto-detection fails or you use a non-standard volume name, you can override it:
+
+```bash
+TSCLIENT_HOME='\\tsclient\Macintosh HD\Users\myuser'
+```
+
+## Windows Setup
+
+1. **Enable Remote Desktop** on the Windows machine
+2. **Import the RemoteApp registry settings**:
+   - Copy `install/RDPApps.reg` to the Windows machine
+   - Double-click to merge it into the registry
+3. Optionally run `install/ExtractPrograms.ps1` to verify app detection
+
+## Install App Shortcuts (Scan-and-Generate)
+
+Run the installer to scan for installed Windows apps and create CLI wrappers:
+
+```bash
+# User install (~/.local/bin)
+bash setup.sh --user
+
+# System install (/usr/local/bin)
+bash setup.sh --system
+```
+
+The installer will:
+1. Connect to your Windows machine via RDP
+2. Scan for installed applications
+3. Create CLI wrapper scripts (e.g., `~/.local/bin/word`, `~/.local/bin/excel`)
+
+On macOS, the installer skips `.desktop` file creation (Linux-only) and creates CLI wrappers only.
+
+## Usage
+
+```bash
+# Full Windows desktop
+winapps windows
+
+# Launch a pre-configured app
+winapps word
+winapps excel
+
+# Launch an app with a file
+winapps word ~/Documents/report.docx
+
+# Launch any Windows executable
+winapps manual "C:\Windows\System32\notepad.exe"
+```
+
+## How It Works
+
+On macOS, WinApps generates `.rdp` files dynamically and opens them with the system `open` command, which delegates to Microsoft "Windows App". This avoids the FreeRDP/XQuartz dependency chain.
+
+- `winapps word` generates a temporary `.rdp` file with RemoteApp settings and opens it
+- `winapps windows` generates a full desktop `.rdp` file
+- Files passed as arguments are mapped through `\\tsclient\<Volume Name>\Users\...` (drive redirection)
+
+### Path Mapping
+
+On Linux, FreeRDP's `+home-drive` flag maps `$HOME` to `\\tsclient\home`.
+
+On macOS, Microsoft "Windows App" with `drivestoredirect:s:*` maps volumes by name:
+`\\tsclient\Macintosh HD\Users\username\...`
+
+WinApps auto-detects the volume name via `diskutil info /` and computes the correct tsclient base path.
+
+## Credential Handling
+
+Passwords are not stored in `.rdp` files for security. The RDP client will prompt for credentials on first connection and can save them in the macOS Keychain.
+
+## Troubleshooting
+
+- **"Windows App" not opening**: Ensure it's installed from the Mac App Store
+- **Connection refused**: Verify `RDP_IP` is correct and RDP is enabled on Windows
+- **RemoteApp not working**: Ensure `install/RDPApps.reg` was merged on the Windows machine
+- **Files not accessible**: Check that drive redirection is enabled (it is by default in generated `.rdp` files)
+- **Wrong volume name detected**: Override with `TSCLIENT_HOME` in your config file
+- **`nc` timeout errors**: macOS uses `-w` flag for timeout instead of the `timeout` wrapper; this is handled automatically

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -15,15 +15,15 @@ Run Windows applications on macOS via RDP RemoteApp, using the system RDP client
 ### Via Homebrew (recommended)
 
 ```bash
-brew tap dingyifei/winapps
+brew tap winapps-org/winapps
 brew install winapps
 ```
 
 ### Manual
 
 ```bash
-git clone https://github.com/dingyifei/winapps-macos.git
-cd winapps-macos
+git clone https://github.com/winapps-org/winapps.git
+cd winapps
 ```
 
 ## Configuration

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -43,14 +43,6 @@ chmod 600 ~/.config/winapps/winapps.conf
 
 Set `RDP_IP` to your Windows machine's IP address. Unlike Linux, macOS does not support KVM auto-detection, so `RDP_IP` is **required**.
 
-### Optional: `TSCLIENT_HOME`
-
-WinApps auto-detects your macOS volume name (e.g., `Macintosh HD`) to compute the correct `\\tsclient\...` path for file passthrough. If auto-detection fails or you use a non-standard volume name, you can override it:
-
-```bash
-TSCLIENT_HOME='\\tsclient\Macintosh HD\Users\myuser'
-```
-
 ## Windows Setup
 
 1. **Enable Remote Desktop** on the Windows machine
@@ -105,16 +97,10 @@ WinApps uses two different RDP approaches on macOS:
 Day-to-day:
 - `winapps word` generates a temporary `.rdp` file with RemoteApp settings and opens it
 - `winapps windows` generates a full desktop `.rdp` file
-- Files passed as arguments are mapped through `\\tsclient\<Volume Name>\Users\...` (drive redirection)
 
 ### Path Mapping
 
 On Linux, FreeRDP's `+home-drive` flag maps `$HOME` to `\\tsclient\home`.
-
-On macOS, Microsoft "Windows App" with `drivestoredirect:s:*` maps volumes by name:
-`\\tsclient\Macintosh HD\Users\username\...`
-
-WinApps auto-detects the volume name via `diskutil info /` and computes the correct tsclient base path.
 
 ## Credential Handling
 
@@ -126,5 +112,4 @@ Passwords are not stored in `.rdp` files for security. The RDP client will promp
 - **Connection refused**: Verify `RDP_IP` is correct and RDP is enabled on Windows
 - **RemoteApp not working**: Ensure `install/RDPApps.reg` was merged on the Windows machine
 - **Files not accessible**: Check that drive redirection is enabled (it is by default in generated `.rdp` files)
-- **Wrong volume name detected**: Override with `TSCLIENT_HOME` in your config file
 - **`nc` timeout errors**: macOS uses `-w` flag for timeout instead of the `timeout` wrapper; this is handled automatically

--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ readonly CONFIG_PATH="${HOME}/.config/winapps/winapps.conf" # UNIX path to the W
 readonly INQUIRER_PATH="./install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
 
 # REMOTE DESKTOP CONFIGURATION
-readonly RDP_PORT=3389         # Port used for RDP on Windows.
+RDP_PORT=3389         # Port used for RDP on Windows. Overridable via config.
 readonly DOCKER_IP="127.0.0.1" # Localhost.
 
 ### GLOBAL VARIABLES ###
@@ -586,14 +586,20 @@ function waCheckScriptDependencies() {
 
         # Display the suggested action(s).
         echo "--------------------------------------------------------------------------------"
-        echo "Debian/Ubuntu-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo apt install git${CLEAR_TEXT}"
-        echo "Red Hat/Fedora-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo dnf install git${CLEAR_TEXT}"
-        echo "Arch Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo pacman -S git${CLEAR_TEXT}"
-        echo "Gentoo Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo emerge --ask dev-vcs/git${CLEAR_TEXT}"
+        if [ "$PLATFORM" = "Darwin" ]; then
+            echo "macOS:"
+            echo -e "  ${COMMAND_TEXT}xcode-select --install${CLEAR_TEXT}"
+            echo -e "  ${COMMAND_TEXT}brew install git${CLEAR_TEXT}"
+        else
+            echo "Debian/Ubuntu-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo apt install git${CLEAR_TEXT}"
+            echo "Red Hat/Fedora-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo dnf install git${CLEAR_TEXT}"
+            echo "Arch Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo pacman -S git${CLEAR_TEXT}"
+            echo "Gentoo Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo emerge --ask dev-vcs/git${CLEAR_TEXT}"
+        fi
         echo "--------------------------------------------------------------------------------"
 
         # Terminate the script.
@@ -610,14 +616,19 @@ function waCheckScriptDependencies() {
 
         # Display the suggested action(s).
         echo "--------------------------------------------------------------------------------"
-        echo "Debian/Ubuntu-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo apt install curl${CLEAR_TEXT}"
-        echo "Red Hat/Fedora-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo dnf install curl${CLEAR_TEXT}"
-        echo "Arch Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo pacman -S curl${CLEAR_TEXT}"
-        echo "Gentoo Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo emerge --ask net-misc/curl${CLEAR_TEXT}"
+        if [ "$PLATFORM" = "Darwin" ]; then
+            echo "macOS:"
+            echo -e "  ${COMMAND_TEXT}brew install curl${CLEAR_TEXT}"
+        else
+            echo "Debian/Ubuntu-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo apt install curl${CLEAR_TEXT}"
+            echo "Red Hat/Fedora-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo dnf install curl${CLEAR_TEXT}"
+            echo "Arch Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo pacman -S curl${CLEAR_TEXT}"
+            echo "Gentoo Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo emerge --ask net-misc/curl${CLEAR_TEXT}"
+        fi
         echo "--------------------------------------------------------------------------------"
 
         # Terminate the script.
@@ -634,14 +645,19 @@ function waCheckScriptDependencies() {
 
         # Display the suggested action(s).
         echo "--------------------------------------------------------------------------------"
-        echo "Debian/Ubuntu-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo apt install dialog${CLEAR_TEXT}"
-        echo "Red Hat/Fedora-based systems:"
-        echo -e "  ${COMMAND_TEXT}sudo dnf install dialog${CLEAR_TEXT}"
-        echo "Arch Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo pacman -S dialog${CLEAR_TEXT}"
-        echo "Gentoo Linux systems:"
-        echo -e "  ${COMMAND_TEXT}sudo emerge --ask dialog${CLEAR_TEXT}"
+        if [ "$PLATFORM" = "Darwin" ]; then
+            echo "macOS:"
+            echo -e "  ${COMMAND_TEXT}brew install dialog${CLEAR_TEXT}"
+        else
+            echo "Debian/Ubuntu-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo apt install dialog${CLEAR_TEXT}"
+            echo "Red Hat/Fedora-based systems:"
+            echo -e "  ${COMMAND_TEXT}sudo dnf install dialog${CLEAR_TEXT}"
+            echo "Arch Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo pacman -S dialog${CLEAR_TEXT}"
+            echo "Gentoo Linux systems:"
+            echo -e "  ${COMMAND_TEXT}sudo emerge --ask dialog${CLEAR_TEXT}"
+        fi
         echo "--------------------------------------------------------------------------------"
 
         # Terminate the script.

--- a/setup.sh
+++ b/setup.sh
@@ -1864,6 +1864,12 @@ function waInstall() {
         return "$EC_INVALID_FLAVOR"
     fi
 
+    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
+    if [ "$PLATFORM" = "Darwin" ]; then
+        [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
+        [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90
+    fi
+
     # Check if the RDP port on Windows is open.
     waCheckPortOpen
 
@@ -2074,6 +2080,12 @@ function waAddApps() {
 
         # Terminate the script.
         return "$EC_INVALID_FLAVOR"
+    fi
+
+    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
+    if [ "$PLATFORM" = "Darwin" ]; then
+        [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
+        [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90
     fi
 
     # Check if the RDP port on Windows is open.

--- a/setup.sh
+++ b/setup.sh
@@ -612,7 +612,6 @@ function waCheckScriptDependencies() {
         if [ "$PLATFORM" = "Darwin" ]; then
             echo "macOS:"
             echo -e "  ${COMMAND_TEXT}xcode-select --install${CLEAR_TEXT}"
-            echo -e "  ${COMMAND_TEXT}brew install git${CLEAR_TEXT}"
         else
             echo "Debian/Ubuntu-based systems:"
             echo -e "  ${COMMAND_TEXT}sudo apt install git${CLEAR_TEXT}"
@@ -640,8 +639,7 @@ function waCheckScriptDependencies() {
         # Display the suggested action(s).
         echo "--------------------------------------------------------------------------------"
         if [ "$PLATFORM" = "Darwin" ]; then
-            echo "macOS:"
-            echo -e "  ${COMMAND_TEXT}brew install curl${CLEAR_TEXT}"
+            echo "macOS should come with curl!"
         else
             echo "Debian/Ubuntu-based systems:"
             echo -e "  ${COMMAND_TEXT}sudo apt install curl${CLEAR_TEXT}"
@@ -1239,7 +1237,7 @@ function waCheckRDPAccess() {
     # shellcheck disable=SC2140,SC2027,SC2086 # Disable warnings regarding unquoted strings.
     $FREERDP_COMMAND \
         $RDP_FLAGS_NON_WINDOWS \
-        /cert:ignore \
+        /cert:tofu \
         /d:"$RDP_DOMAIN" \
         /u:"$RDP_USER" \
         /p:"$RDP_PASS" \

--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,7 @@ readonly CONFIG_PATH="${HOME}/.config/winapps/winapps.conf" # UNIX path to the W
 readonly INQUIRER_PATH="./install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
 
 # REMOTE DESKTOP CONFIGURATION
-RDP_PORT=3389         # Port used for RDP on Windows. Overridable via config.
+readonly RDP_PORT=3389         # Port used for RDP on Windows.
 readonly DOCKER_IP="127.0.0.1" # Localhost.
 
 ### GLOBAL VARIABLES ###

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,8 @@ readonly EC_APPQUERY_FAIL="15"   # Failed to query Windows for installed applica
 readonly EC_INVALID_FLAVOR="16"  # Backend specified is not 'libvirt', 'docker' or 'podman'.
 
 # PLATFORM
-readonly PLATFORM="$(uname -s)"
+PLATFORM="$(uname -s)"
+readonly PLATFORM
 
 # HOMEBREW PREFIX (macOS only)
 HOMEBREW_PREFIX=""
@@ -1335,7 +1336,7 @@ function waFindInstalled() {
     if [ "$PLATFORM" = "Darwin" ]; then
         {
             echo ":WAIT_DRIVE"
-            echo "if exist \\\\tsclient\\home goto DRIVE_READY"
+            printf '%s\n' "if exist \\\\tsclient\\home goto DRIVE_READY"
             echo "ping -n 3 127.0.0.1 >NUL"
             echo "goto WAIT_DRIVE"
             echo ":DRIVE_READY"

--- a/setup.sh
+++ b/setup.sh
@@ -1864,7 +1864,7 @@ function waInstall() {
         return "$EC_INVALID_FLAVOR"
     fi
 
-    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
+    # macOS: xFreeRDP on xquartz adds ~15s overhead; increase timeouts.
     if [ "$PLATFORM" = "Darwin" ]; then
         [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
         [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90
@@ -2082,7 +2082,7 @@ function waAddApps() {
         return "$EC_INVALID_FLAVOR"
     fi
 
-    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
+    # macOS: xFreeRDP on xquartz adds ~15s overhead; increase timeouts.
     if [ "$PLATFORM" = "Darwin" ]; then
         [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
         [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90

--- a/setup.sh
+++ b/setup.sh
@@ -1225,14 +1225,8 @@ function waCheckRDPAccess() {
     # Note: The following final line is expected within the log, indicating successful execution of the 'tsdiscon' command and termination of the RDP session.
     # [INFO][com.freerdp.core] - [rdp_print_errinfo]: ERRINFO_LOGOFF_BY_USER (0x0000000C):The disconnection was initiated by the user logging off their session on the server.
 
-    # macOS: FreeRDP's +home-drive takes ~10s to register \\tsclient\home.
-    # Add a delay before accessing the drive. Use '&' so tsdiscon always runs.
     local CMD_STRING
-    if [ "$PLATFORM" = "Darwin" ]; then
-        CMD_STRING="/C ping -n 16 127.0.0.1 >NUL & type NUL > $TEST_PATH_WIN & tsdiscon"
-    else
-        CMD_STRING="/C type NUL > $TEST_PATH_WIN && tsdiscon"
-    fi
+    CMD_STRING="/C type NUL > $TEST_PATH_WIN && tsdiscon"
 
     # shellcheck disable=SC2140,SC2027,SC2086 # Disable warnings regarding unquoted strings.
     $FREERDP_COMMAND \
@@ -1713,7 +1707,7 @@ function waConfigureDetectedApps() {
         # On WINDOWS systems, lines are terminated with both a carriage return (\r) and a newline (\n) character.
         # Remove all carriage returns (\r) within the 'detected' file, as the file was written by Windows.
         if [ "$PLATFORM" = "Darwin" ]; then
-            sed -i '' 's/\r//g' "$DETECTED_FILE_PATH"
+            sed -i '' 's/\r//g' "$DETECTED_FILE_PATH" # BSD sed require explisit '' for "no backup file"
         else
             sed -i 's/\r//g' "$DETECTED_FILE_PATH"
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -34,8 +34,8 @@ readonly EC_APPQUERY_FAIL="15"   # Failed to query Windows for installed applica
 readonly EC_INVALID_FLAVOR="16"  # Backend specified is not 'libvirt', 'docker' or 'podman'.
 
 # PLATFORM
-PLATFORM="$(uname -s)"
-readonly PLATFORM
+# shellcheck disable=SC2155 # Silence warnings regarding masking return values through simultaneous declaration and assignment.
+readonly PLATFORM="$(uname -s)"
 
 # HOMEBREW PREFIX (macOS only)
 HOMEBREW_PREFIX=""

--- a/setup.sh
+++ b/setup.sh
@@ -1876,12 +1876,6 @@ function waInstall() {
         return "$EC_INVALID_FLAVOR"
     fi
 
-    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
-    if [ "$PLATFORM" = "Darwin" ]; then
-        [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
-        [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90
-    fi
-
     # Check if the RDP port on Windows is open.
     waCheckPortOpen
 
@@ -2092,12 +2086,6 @@ function waAddApps() {
 
         # Terminate the script.
         return "$EC_INVALID_FLAVOR"
-    fi
-
-    # macOS: FreeRDP drive registration adds ~15s overhead; increase timeouts.
-    if [ "$PLATFORM" = "Darwin" ]; then
-        [ "$RDP_TIMEOUT" -lt 60 ] && RDP_TIMEOUT=60
-        [ "$APP_SCAN_TIMEOUT" -lt 90 ] && APP_SCAN_TIMEOUT=90
     fi
 
     # Check if the RDP port on Windows is open.

--- a/setup.sh
+++ b/setup.sh
@@ -1323,18 +1323,6 @@ function waFindInstalled() {
     # This will enable the PowerShell script to be accessed and executed by Windows.
     cp "$PS_SCRIPT_PATH" "$PS_SCRIPT_HOME_PATH"
 
-    # macOS: FreeRDP's +home-drive takes ~10s to register \\tsclient\home.
-    # Prepend a polling loop so the drive is available when batch commands run.
-    if [ "$PLATFORM" = "Darwin" ]; then
-        {
-            echo ":WAIT_DRIVE"
-            printf '%s\n' "if exist \\\\tsclient\\home goto DRIVE_READY"
-            echo "ping -n 3 127.0.0.1 >NUL"
-            echo "goto WAIT_DRIVE"
-            echo ":DRIVE_READY"
-        } >"$BATCH_SCRIPT_PATH"
-    fi
-
     # Enumerate over each officially supported application.
     for APPLICATION in ./apps/*; do
         # Extract the name of the application from the absolute path of the folder.


### PR DESCRIPTION
The commits are mostly generated by Claude Code. I've reviewed most parts of it

This is a minimal implementation that enable MacOS to install winapps using `homebrew` and run `winapps-setup` and `winapps`. A few wrappers were made to make winapps compatible with macos, such as waNotify. Due to limitations on MacOS, most features utilizing waNotify are not compatible with macOS yet

Since xquartz + xfreerdp have been terrible (glitching, black screen,...) on newer macOS, xfreerdp is only used for the winapps-setup to run app detection script. For connecting, Windows App is used with .rdp for app mode. It appears to work well (without dock icons unfortunately, it's a limitation). However, there seems to be some difficulties in disconnecting the client from host after all the windows are closed. 

Features such as using `winapp <app_name> <file_path>` are tested and works on my machine.

note that xquartz is a homebrew cask, so it needs to be manually installed and can not be a prereq of the formula.

Closes #35 