### PR TITLE
Propagate configured RDP port to app launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ RDP_DOMAIN=""
 # - 'libvirt': '' (BLANK)
 RDP_IP="127.0.0.1"
 
+# [RDP PORT]
+# NOTES:
+# - For Docker and Podman, this is the host port mapped to Windows port 3389.
+# - If you changed the host-side RDP port in compose.yaml, set this to match.
+# DEFAULT VALUE: '3389'
+RDP_PORT="3389"
+
 # [VM NAME]
 # NOTES:
 # - Only applicable when using 'libvirt'
@@ -576,13 +583,13 @@ HIDEF="on"
 1. Test establishing an RDP session by running the following command, replacing the `/u:`, `/p:`, and `/v:` values with the correct values specified in `~/.config/winapps/winapps.conf`.
 
     ```bash
-    xfreerdp3 /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1 /cert:tofu
+    xfreerdp3 /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1:3389 /cert:tofu
 
     # Or, if you are using Podman
-    podman unshare --rootless-netns xfreerdp3 /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1 /cert:tofu
+    podman unshare --rootless-netns xfreerdp3 /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1:3389 /cert:tofu
 
     # Or, if you installed FreeRDP using Flatpak
-    flatpak run --command=xfreerdp com.freerdp.FreeRDP /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1 /cert:tofu
+    flatpak run --command=xfreerdp com.freerdp.FreeRDP /u:"MyWindowsUser" /p:"MyWindowsPassword" /v:127.0.0.1:3389 /cert:tofu
     ```
 
     - Please note that the correct `FreeRDP` command may vary depending on your system (e.g. `xfreerdp`, `xfreerdp3`, etc.).

--- a/bin/winapps
+++ b/bin/winapps
@@ -32,7 +32,7 @@ readonly SLEEP_MARKER="${APPDATA_PATH}/sleep_marker"
 
 # OTHER
 readonly CONTAINER_NAME="WinApps" # FOR 'docker' AND 'podman' ONLY
-readonly RDP_PORT=3389
+RDP_PORT=3389
 readonly DOCKER_IP="127.0.0.1"
 # shellcheck disable=SC2155 # Silence warnings regarding masking return values through simultaneous declaration and assignment.
 readonly RUNID="${RANDOM}"
@@ -370,6 +370,8 @@ function waLoadConfig() {
     else
         waThrowExit $EC_MISSING_CONFIG
     fi
+
+    RDP_PORT="${RDP_PORT:-3389}"
 
     # Update $RDP_SCALE.
     waFixScale
@@ -787,7 +789,7 @@ function waRunCommand() {
             +dynamic-resolution \
             /wm-class:"Microsoft Windows" \
             /t:"Windows RDP Session [$RDP_IP]" \
-            /v:"$RDP_IP" &>/dev/null &
+            /v:"$RDP_IP":"$RDP_PORT" &>/dev/null &
 
         # Capture the process ID.
         FREERDP_PID=$!
@@ -803,7 +805,7 @@ function waRunCommand() {
             /scale:"$RDP_SCALE" \
             +auto-reconnect \
             /app:program:"$2",hidef:"$HIDEF" \
-            /v:"$RDP_IP" &>/dev/null &
+            /v:"$RDP_IP":"$RDP_PORT" &>/dev/null &
 
         # Capture the process ID.
         FREERDP_PID=$!
@@ -838,7 +840,7 @@ function waRunCommand() {
                 +auto-reconnect \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",hidef:"$HIDEF",icon:"$ICON",name:"$FULL_NAME" \
-                /v:"$RDP_IP" &>/dev/null &
+                /v:"$RDP_IP":"$RDP_PORT" &>/dev/null &
 
             # Capture the process ID.
             FREERDP_PID=$!
@@ -862,7 +864,7 @@ function waRunCommand() {
                 /drive:media,"$REMOVABLE_MEDIA" \
                 /wm-class:"$FULL_NAME" \
                 /app:program:"$WIN_EXECUTABLE",hidef:"$HIDEF",icon:"$ICON",name:"$FULL_NAME",cmd:\""$FILE_PATH"\" \
-                /v:"$RDP_IP" &>/dev/null &
+                /v:"$RDP_IP":"$RDP_PORT" &>/dev/null &
 
             # Capture the process ID.
             FREERDP_PID=$!

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -53,6 +53,7 @@ docker compose --file ~/.config/winapps/compose.yaml down
 
 # Remove the existing FreeRDP certificate (if required).
 # Note: A new certificate will be created when connecting via RDP for the first time.
+# If you configured a custom RDP_PORT, replace 3389 with that port.
 rm ~/.config/freerdp/server/127.0.0.1_3389.pem
 
 # Re-create the container with the updated configuration.
@@ -105,6 +106,7 @@ podman-compose --file ~/.config/winapps/compose.yaml down
 
 # Remove the existing FreeRDP certificate (if required).
 # Note: A new certificate will be created when connecting via RDP for the first time.
+# If you configured a custom RDP_PORT, replace 3389 with that port.
 rm ~/.config/freerdp/server/127.0.0.1_3389.pem
 
 # Re-create the container with the updated configuration.

--- a/packages/winapps/setup.patch
+++ b/packages/winapps/setup.patch
@@ -21,7 +21,7 @@ index 3a871c8..71a8fa0 100755
 +readonly INQUIRER_PATH="@out@/src/install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
  
  # REMOTE DESKTOP CONFIGURATION
- readonly RDP_PORT=3389         # Port used for RDP on Windows.
+ RDP_PORT=3389                  # Port used for RDP on Windows.
 @@ -157,13 +157,6 @@ function waGetSourceCode() {
          echo -e "${WARNING_TEXT}[WARNING]${CLEAR_TEXT} You might want to remove your old installation on '${SCRIPT_DIR_PATH}'."
      fi

--- a/setup.sh
+++ b/setup.sh
@@ -73,7 +73,7 @@ readonly CONFIG_PATH="${HOME}/.config/winapps/winapps.conf" # UNIX path to the W
 readonly INQUIRER_PATH="./install/inquirer.sh" # UNIX path to the 'inquirer' script, which is used to produce selection menus.
 
 # REMOTE DESKTOP CONFIGURATION
-readonly RDP_PORT=3389         # Port used for RDP on Windows.
+RDP_PORT=3389                  # Port used for RDP on Windows.
 readonly DOCKER_IP="127.0.0.1" # Localhost.
 
 ### GLOBAL VARIABLES ###
@@ -561,6 +561,8 @@ function waLoadConfig() {
         # Load the WinApps configuration file.
         # shellcheck source=/dev/null # Exclude this file from being checked by ShellCheck.
         source "$CONFIG_PATH"
+
+        RDP_PORT="${RDP_PORT:-3389}"
 
         # Send password on the command line if a command to retrieve the password from is not given
         # Otherwise, set FREERDP_ASKPASS which freerdp will read the stdout of to use as the password
@@ -1132,7 +1134,7 @@ function waCheckRDPAccess() {
         +auto-reconnect \
         +home-drive \
         /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C type NUL > $TEST_PATH_WIN && tsdiscon" \
-        /v:"$RDP_IP" &>"$FREERDP_LOG" &
+        /v:"$RDP_IP":"$RDP_PORT" &>"$FREERDP_LOG" &
 
     # Store the FreeRDP process ID.
     FREERDP_PROC=$!
@@ -1265,7 +1267,7 @@ function waFindInstalled() {
         +auto-reconnect \
         +home-drive \
         /app:program:"C:\Windows\System32\cmd.exe",cmd:"/C "$BATCH_SCRIPT_PATH_WIN"" \
-        /v:"$RDP_IP" &>"$FREERDP_LOG" &
+        /v:"$RDP_IP":"$RDP_PORT" &>"$FREERDP_LOG" &
 
     # Store the FreeRDP process ID.
     FREERDP_PROC=$!


### PR DESCRIPTION
Fix https://github.com/Fmstrat/winapps/issues/382
## Summary
- make RDP_PORT configurable from winapps.conf instead of readonly defaults
- pass RDP_PORT through all FreeRDP launch /v: arguments
- document the RDP_PORT setting and custom-port certificate note