### PR TITLE
Added few lines to README to inform about debian 12 specific freerdp issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Install the required dependencies.
 > For instructions, see https://backports.debian.org/Instructions.
 
 > [!IMPORTANT]
-> Also, after downloading `freerdp3-x11` on Debian 12, you may need to activate legacy openssl provider by redacting `/etc/ssl/openssl.cnf`, otherwise freerdp3 will fail silently. 
+> Also, after downloading `freerdp3-x11` on Debian 12, you may need to activate legacy openssl provider by redacting `/etc/ssl/openssl.cnf`, otherwise freerdp3 will fail silently.
 > For instructions, see https://lindevs.com/enable-openssl-legacy-provider-on-ubuntu.
 
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,11 @@ Install the required dependencies.
 > On Debian 12 (_"bookworm"_), you need to enable the `backports` repository for the `freerdp3-x11` package to become available.
 > For instructions, see https://backports.debian.org/Instructions.
 
+> [!IMPORTANT]
+> Also, after downloading `freerdp3-x11` on Debian 12, you may need to activate legacy openssl provider by redacting `/etc/ssl/openssl.cnf`, otherwise freerdp3 will fail silently. 
+> For instructions, see https://lindevs.com/enable-openssl-legacy-provider-on-ubuntu.
+
+
   - Fedora/RHEL:
       ```bash
       sudo dnf install -y curl dialog freerdp git iproute libnotify nmap-ncat


### PR DESCRIPTION
My winapps setup on debian 12 has stopped working for some reason, launching apps were failing without any errors.
Launching from terminal revealed that freerdp3 was failing specifically:

```
[16:02:49:573] [81770:00013f6a] [WARN][com.freerdp.core.rdp] - [log_build_warn_cipher][0x556089b48ca0]: [SSL] {Cipher}
build or configuration missing: [16:02:49:573] [81770:00013f6a] [WARN][com.freerdp.core.rdp] - [log_build_warn_cipher]
[0x556089b48ca0]: * rc4: assistance files with encrypted passwords, NTLM, RDP licensing and RDP security will not work 
```
Also I got this error recreated in a VM with clean debian 12 setup to be sure.

The cause is that current openssl3 library doesn't provide obsolete algorithms support, which are used in RDP protocol, by default. It has to be activated manually via changing `/etc/ssl/openssl.cnf` file and appending next lines:

```
[provider_sect]
legacy = legacy_sect

[legacy_sect]
activate = 1
```

The point is ```openssl list -providers``` should have output with two providers: default and legacy:
```
Providers:
  default
    name: OpenSSL Default Provider
    version: 3.0.2
    status: active
  legacy
    name: OpenSSL Legacy Provider
    version: 3.0.2
    status: active
```

Also may be a good idea to implement config change in installer by user confirming.



